### PR TITLE
Another attempt at fixing build/push

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -57,8 +57,8 @@ jobs:
       id: push-back-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.build-back.outputs.image }}
-        tags: ${{ steps.build-back.outputs.tags }}
+        image: backend
+        tags: latest ${{ github.sha }}
         registry: quay.io/cloud-bulldozer
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/release-build-push.yaml
+++ b/.github/workflows/release-build-push.yaml
@@ -59,8 +59,8 @@ jobs:
       id: push-back-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.build-back.outputs.image }}
-        tags: ${{ steps.build-back.outputs.tags }}
+        image: backend
+        tags: prod ${{ github.sha }}
         registry: quay.io/cloud-bulldozer
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After modifying the container build workflows to use `podman build` (which works) rather than `buildah bud` (through the `redhat-actions/buildah-build` action, which blows up), I neglected to fix the `push-to-registry` action input parameters, which depended on the `buildah-bud` action outputs.

Unfortunately, this puts me back into territory that will only be tested on merge into main.

## Related Tickets & Documents

[PANDA-1044](https://issues.redhat.com/browse/PANDA-1044) fix container build

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

This can't be tested locally.