### PR TITLE
Add new "summary" APIs to CPT dashboard

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -11,6 +11,7 @@ from app.api.v1.endpoints.ocm import ocmJobs
 from app.api.v1.endpoints.ocp import graph, ocpJobs, results
 from app.api.v1.endpoints.ols import olsGraphs, olsJobs
 from app.api.v1.endpoints.quay import quayGraphs, quayJobs
+from app.api.v1.endpoints.summary import summary_api
 from app.api.v1.endpoints.telco import telcoGraphs, telcoJobs
 
 router = APIRouter()
@@ -46,6 +47,9 @@ router.include_router(ocmJobs.router, tags=["ocm"])
 
 # InstructLab endpoint
 router.include_router(router=ilab.router, tags=["ilab"])
+
+# Summary endpoint
+router.include_router(summary_api.router, tags=["summary"])
 
 
 @router.get(

--- a/backend/app/api/v1/endpoints/ocp/summary.py
+++ b/backend/app/api/v1/endpoints/ocp/summary.py
@@ -1,0 +1,760 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+import time
+from typing import Any, Optional
+
+from app.api.v1.commons.constants import AGG_BUCKET_SIZE, MAX_PAGE
+from app.api.v1.endpoints.summary.summary import BenchmarkBase
+from app.api.v1.endpoints.summary.summary_search import (
+    Benchmark,
+    PerfCiFingerprint,
+    SearchBenchmark,
+    SummarySearch,
+)
+
+"""OCP implementation of Summary class
+
+AI assistance: Cursor is extremely helpful in generating suggesting code
+snippets along the way. While most of this code is hand generated as the
+relationships are tricky and difficult to describe to the AI, it's been
+extremely helpful as an "over the shoulder assistant" to simplify routine
+coding tasks.
+
+Assisted-by: Cursor + claude-4-sonnet
+"""
+
+
+BENCHMARK_INDEX: dict[str, Benchmark | None] = {
+    "amadeus-mgob-usecase": None,
+    "amadeus-usecase": None,
+    "cluster-density": Benchmark(
+        index="ripsaw-kube-burner",
+        filter={
+            "metricName.keyword": "podLatencyQuantilesMeasurement",
+            "quantileName.keyword": "Ready",
+        },
+    ),
+    "cluster-density-v2": Benchmark(
+        index="ripsaw-kube-burner",
+        filter={
+            "metricName.keyword": "podLatencyQuantilesMeasurement",
+            "quantileName.keyword": "Ready",
+        },
+    ),
+    "concurrent-builds": None,
+    "crd-scale": None,
+    "custom": None,
+    "index": None,
+    "ingress-perf": Benchmark("ingress-performance"),
+    "k8s-netperf": Benchmark("k8s-netperf"),
+    "kueue-operator-jobs": None,
+    "kueue-operator-jobs-shared": None,
+    "kueue-operator-pods": Benchmark(
+        index="ripsaw-kube-burner",
+        filter={
+            "metricName.keyword": "podLatencyQuantilesMeasurement",
+            "quantileName.keyword": "Ready",
+        },
+    ),
+    "large-networkpolicy-egress": None,
+    "network-policy": None,
+    "networkpolicy-case1": None,
+    "networkpolicy-case2": None,
+    "networkpolicy-case-amadeus-mgob": None,
+    "node-density": None,
+    "node-density-cni": None,
+    "node-density-cni-networkpolicy": None,
+    "node-density-heavy": None,
+    "olm": Benchmark(
+        index="ripsaw-kube-burner",
+        filter={
+            "metricName.keyword": "nodeLatencyQuantilesMeasurement",
+            "quantileName.keyword": "Ready",
+        },
+    ),
+    "ols-load-generator": None,
+    "ovn-live-migration": None,
+    "rds-core": None,
+    "router-perf": None,
+    "udn-density-l3-pods": None,
+    "udn-density-pods": None,
+    "virt-density": Benchmark(
+        index="ripsaw-kube-burner",
+        filter={
+            "metricName.keyword": "vmiLatencyQuantilesMeasurement",
+            "quantileName.keyword": "VMIRunning",
+        },
+    ),
+    "virt-udn-density": None,
+    "web-burner-cluster-density": None,
+    "web-burner-init": None,
+    "web-burner-node-density": None,
+    "workers-scale": None,
+}
+
+
+@dataclass
+class OcpFingerprint(PerfCiFingerprint):
+    platform: str = field(metadata={"str": "p", "key": True})
+
+
+class OcpSummary(SummarySearch):
+
+    def __init__(self, product: str, configpath: str = "ocp.elasticsearch"):
+        super().__init__(product, configpath, BENCHMARK_INDEX)
+
+    async def close(self):
+        """Close the summary service."""
+        await super().close()
+
+    def create_helper(self, benchmark: str) -> "BenchmarkBase":
+        match self.get_index(benchmark):
+            case "ripsaw-kube-burner":
+                helper = KubeBurnerBenchmark(self, benchmark)
+            case "k8s-netperf":
+                helper = K8sNetperfBenchmark(self, benchmark)
+            case "ingress-performance":
+                helper = IngressPerfBenchmark(self, benchmark)
+            case _:
+                raise ValueError(f"Unsupported benchmark: {benchmark}")
+        return helper
+
+    async def get_versions(self) -> dict[str, list[str]]:
+        """Return a list of versions.
+
+        Returns:
+            The full version strings for each "short version" (e.g. "4.19").
+        """
+        start = time.time()
+        filters = [{"match": {"jobStatus": "success"}}]
+        if self.date_filter:
+            filters.append(self.date_filter)
+
+        query = {
+            "size": 0,
+            "query": {"bool": {"filter": filters}},
+            "aggs": {
+                "versions": {
+                    "terms": {
+                        "field": "ocpVersion.keyword",
+                        "size": AGG_BUCKET_SIZE,
+                    },
+                }
+            },
+        }
+        response = await self.service.post(query=query, size=0)
+        versions = defaultdict(set)
+        for version in response["aggregations"]["versions"]["buckets"]:
+            v = version["key"]
+            versions[v[:4]].add(v)
+
+        print(f"discovered {len(versions)} versions: {time.time()-start:3f} seconds")
+        return {k: sorted(v) for k, v in versions.items()}
+
+    async def get_benchmarks(self, version: str) -> dict[str, Any]:
+        """Return a list of benchmarks run for a given product version.
+
+        Args:
+            version: The product version to get benchmarks for.
+
+        Returns:
+            A list of benchmarks and the configurations for which each is run.
+        """
+        filters = [
+            {"match": {"jobStatus": "success"}},
+        ]
+        if self.date_filter:
+            filters.append(self.date_filter)
+        print("get_benchmarks", version)
+        query = {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "filter": filters,
+                    "must": [{"query_string": {"query": f"ocpVersion:{version}*"}}],
+                },
+            },
+            "aggs": {
+                "configurations": {
+                    "composite": {
+                        "sources": OcpFingerprint.composite(),
+                        "size": AGG_BUCKET_SIZE,
+                    },
+                    "aggs": {
+                        "benchmarks": {
+                            "terms": {
+                                "field": "benchmark.keyword",
+                                "size": AGG_BUCKET_SIZE,
+                            },
+                            "aggs": {
+                                "uuids": {
+                                    "terms": {
+                                        "field": "uuid.keyword",
+                                        "size": AGG_BUCKET_SIZE,
+                                    }
+                                },
+                            },
+                        }
+                    },
+                },
+            },
+        }
+        start = time.time()
+        response = await self.service.post(query=query, size=0)
+        benchmarks = set()
+        by_benchmark = defaultdict(list)
+        for config in response["aggregations"]["configurations"]["buckets"]:
+            bees = defaultdict(set)
+            for benchmark in config["benchmarks"]["buckets"]:
+                benchmarks.add(benchmark["key"])
+                for uuid in benchmark["uuids"]["buckets"]:
+                    bees[benchmark["key"]].add(uuid["key"])
+            for b, u in bees.items():
+                by_benchmark[b].append(
+                    {
+                        "configuration": OcpFingerprint.parse(config["key"]),
+                        "uuids": list(u),
+                    }
+                )
+                benchmarks.add(b)
+        print(
+            f"discovered {version} benchmark hierarchy: {time.time()-start:3f} seconds"
+        )
+        return dict(by_benchmark)
+
+    async def get_iterations(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Break down our benchmark configuration data by job iterations.
+
+        We can only compare benchmark metrics across the same configuration and
+        job iteration count. While the configuration data is in the job
+        documents, the job iteration count is recorded within a special
+        "jobConfiguration" metric.
+
+        This function identifies the set of jobs that can be compared based on
+        identical configuration and iteration count.
+
+        TODO: this should allow targeting a specific OCP configuration.
+        (Although I've yet to figure out how to compactly represent the
+        configuration tuple in a query parameter.)
+        """
+        start = time.time()
+
+        vees = sorted(
+            (await self.get_versions()).keys()
+            if not versions
+            else self.break_list(versions)
+        )
+
+        benches = self.break_list(benchmarks) if benchmarks else None
+
+        benchmark_metrics = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        )
+        config_key = defaultdict(dict)
+        for ver in vees:
+            bees = await self.get_benchmarks(ver)
+            for benchmark, configurations in bees.items():
+                if benches and benchmark not in benches:
+                    continue
+
+                # get the index -- and, for now, we only know what to make of
+                # kube-burner benchmarks.
+                idx = self.get_index(benchmark)
+                if not idx:
+                    continue
+
+                for config in configurations:
+                    uuids = sorted(config["uuids"])
+                    ck = config["configuration"].key()
+                    config_key[ck] = config["configuration"].json()
+                    try:
+                        klass = self.get_helper(benchmark)
+                    except ValueError as e:
+                        print(f"No {ver} {benchmark} {ck} variants: {e}")
+                        benchmark_metrics[ver][benchmark][ck] = {}
+                        continue
+                    variants = await klass.get_iteration_variants(idx, uuids)
+                    if not variants:
+                        print(f"No {ver} {benchmark} {ck} variants found")
+                        benchmark_metrics[ver][benchmark][ck] = {}
+                        continue
+                    for iter, uuids in variants.items():
+                        benchmark_metrics[ver][benchmark][ck][iter].extend(uuids)
+        benchmark_report = {
+            "config_key": config_key,
+            "benchmarks": {
+                v: {
+                    b: {
+                        c: {j: sorted(u) for j, u in vs.items()} for c, vs in cf.items()
+                    }
+                    for b, cf in d.items()
+                }
+                for v, d in benchmark_metrics.items()
+            },
+        }
+        print(f"benchmark iterations: {time.time()-start:.3f} seconds")
+        return benchmark_report
+
+    async def get_configs(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        uuids: Optional[bool] = False,
+    ) -> dict[str, Any]:
+        """Return report the number of job iterations for each benchmark
+        configuration.
+
+        Args:
+            versions: The OCP versions to get configurations for.
+            benchmarks: The benchmarks to get configurations for.
+
+        Returns:
+            A report of the number of job iterations for each benchmark
+            configuration.
+        """
+        data = await self.get_iterations(versions, benchmarks)
+        configs = {
+            "config_key": data["config_key"],
+            "benchmarks": {
+                v: {
+                    b: {
+                        c: {j: (u if uuids else len(u)) for j, u in vs.items()}
+                        for c, vs in cf.items()
+                    }
+                    for b, cf in d.items()
+                }
+                for v, d in data["benchmarks"].items()
+            },
+        }
+        return configs
+
+    def is_ready(self, readiness: set[str]) -> str:
+        """Determine if the set of readiness indicators is "ready".
+
+        Args:
+            readiness: A set of readiness indicators.
+
+        Returns:
+            "ready", "warning", or "not ready"
+        """
+        return (
+            "not ready"
+            if "not ready" in readiness
+            else "warning" if "warning" in readiness else "ready"
+        )
+
+    async def metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Report aggregated metrics for each benchmark configuration.
+
+        For each selected version, benchmark, configuration, report on the
+        primary "readiness" KPI. The results include a list of individual
+        timestamped values, a statistical summary, and a Plotly-formatted
+        graph of the individual runs.
+
+        Args:
+            versions: Select only the named versions (comma-separated list)
+            benchmarks: Select only the named benchmarks (comma-separated list)
+            configs: Select only the named configurations (comma-separated list)
+
+        """
+        start = time.time()
+
+        iterations = await self.get_iterations(versions, benchmarks)
+        breakdown = iterations["benchmarks"]
+        version_samples = defaultdict()
+        product_readiness = set()
+        for ver, benchmarks in breakdown.items():
+            version_readiness = set()
+            benchmark_samples = defaultdict()
+            for benchmark, configs in benchmarks.items():
+                try:
+                    klass = self.get_helper(benchmark)
+                except ValueError as e:
+                    print(f"Benchmark {benchmark} not supported: {e}")
+                    continue
+                benchmark_readiness = set()
+                config_samples = defaultdict()
+                for config, job_iterations in configs.items():
+                    config_readiness = set()
+                    iteration_samples = defaultdict()
+                    for variation, uuids in job_iterations.items():
+                        sample = await klass.process(ver, config, variation, uuids)
+                        readiness = await klass.evaluate(sample)
+                        config_readiness.add(readiness)
+                        sample["readiness"] = readiness
+                        iteration_samples[variation] = sample
+                    config_samples[config] = {
+                        "iterations": iteration_samples,
+                        "readiness": self.is_ready(config_readiness),
+                    }
+                    benchmark_readiness.update(config_readiness)
+                benchmark_samples[benchmark] = {
+                    "configurations": config_samples,
+                    "readiness": self.is_ready(benchmark_readiness),
+                }
+                version_readiness.update(benchmark_readiness)
+            version_samples[ver] = {
+                "benchmarks": benchmark_samples,
+                "readiness": self.is_ready(version_readiness),
+            }
+            product_readiness.update(version_readiness)
+        print(f"benchmark KPI report: {time.time()-start:.3f} seconds")
+        return {
+            "config_key": iterations["config_key"],
+            "versions": version_samples,
+            "readiness": self.is_ready(product_readiness),
+        }
+
+
+class KubeBurnerBenchmark(SearchBenchmark):
+
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, list[str]]:
+        summary = self.summary
+        filters = [
+            {"terms": {"uuid.keyword": uuids}},
+            {"term": {"metricName.keyword": "jobSummary"}},
+        ]
+        if summary.date_filter:
+            filters.append(summary.date_filter)
+        query = {
+            "query": {"bool": {"filter": filters}},
+            "aggs": {
+                "jobIterations": {
+                    "terms": {
+                        "field": "jobConfig.jobIterations",
+                        "size": 10000,
+                    },
+                    "aggs": {
+                        "uuids": {
+                            "terms": {
+                                "field": "uuid.keyword",
+                                "size": 10000,
+                            }
+                        }
+                    },
+                },
+            },
+        }
+
+        response = await summary.service.post(indice=index, query=query, size=0)
+        variants = defaultdict(list)
+        for iterations in response["aggregations"]["jobIterations"]["buckets"]:
+            us = sorted([u["key"] for u in iterations["uuids"]["buckets"]])
+            variants[iterations["key"]].extend(us)
+        return variants
+
+    async def process(
+        self, version: str, config: str, variant: Any, uuids: list[str]
+    ) -> dict[str, Any]:
+        summary = self.summary
+        filters = [{"terms": {"uuid.keyword": uuids}}]
+        if summary.date_filter:
+            filters.append(summary.date_filter)
+        filter = summary.get_filter(self.benchmark)
+        if filter:
+            filters.extend([{"term": {k: v}} for k, v in filter.items()])
+        response = await summary.service.post(
+            indice=self.index,
+            size=MAX_PAGE,
+            query={
+                "query": {"bool": {"filter": filters}},
+                "sort": [{"timestamp": {"order": "asc"}}],
+                "aggs": {
+                    "stats": {
+                        "extended_stats": {
+                            "field": "P99",
+                        }
+                    },
+                },
+            },
+        )
+        x = []
+        y = []
+        values = []
+        for hit in response["hits"]["hits"]:
+            v = hit["_source"]
+            values.append(
+                {
+                    "uuid": v["uuid"],
+                    "timestamp": v["timestamp"],
+                    "value": v["P99"],
+                }
+            )
+            x.append(v["timestamp"])
+            y.append(int(v["P99"]))
+        stats = response["aggregations"]["stats"]
+        sample = {
+            "values": values,
+            "graph": {
+                "x": x,
+                "y": y,
+                "name": f"{version} {self.benchmark} {config} {variant}",
+                "type": "scatter",
+                "mode": "lines+markers",
+                "orientation": "v",
+            },
+            "stats": {
+                "min": stats["min"],
+                "max": stats["max"],
+                "avg": stats["avg"],
+                "std_dev": stats["std_deviation"],
+            },
+        }
+        return sample
+
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Evaluate a metric sample for the primary "readiness" KPI.
+
+        This adds a "readiness" indicator to the metric sample, based on
+        defined thresholds.
+
+        *** WARNING ***
+
+        This is a dummy implementation based on trivial and arbitrary rules.
+
+        *** END WARNING ***
+
+        The benchmark is "not ready" if:
+
+        * If the final value is below the average value, the metric is "not
+          ready".
+
+        The metric can also be "warning" state if:
+
+        * If the standard deviation exceeds half the average value, the metric
+          is "warning".
+
+        Args:
+            metric: A dictionary containing the metric sample.
+
+        Returns:
+            "ready", "warning", or "not ready"
+        """
+        if len(metric["values"]) < 2:
+            print(f"{self.benchmark} evaluating empty metric")
+            return "warning"
+        if metric["values"][-1]["value"] < metric["stats"]["avg"]:
+            return "not ready"
+        if metric["stats"]["std_dev"] > metric["stats"]["avg"] / 2:
+            return "warning"
+        return "ready"
+
+
+class K8sNetperfBenchmark(SearchBenchmark):
+
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, list[str]]:
+        """This benchmark doesn't have separate iteration counts to track."""
+        return {"n/a": uuids}
+
+    async def process(
+        self, version: str, config: str, variant: Any, uuids: list[str]
+    ) -> dict[str, Any]:
+        summary = self.summary
+        filters = [{"terms": {"uuid.keyword": uuids}}]
+        if summary.date_filter:
+            filters.append(summary.date_filter)
+        filter = summary.get_filter(self.benchmark)
+        if filter:
+            filters.extend([{"term": {k: v}} for k, v in filter.items()])
+        response = await summary.service.post(
+            indice=self.index,
+            size=0,
+            query={
+                "query": {"bool": {"filter": filters}},
+                "sort": [{"timestamp": {"order": "asc"}}],
+                "aggs": {
+                    "stats": {
+                        "extended_stats": {
+                            "field": "throughput",
+                        }
+                    },
+                    "uuid": {
+                        "terms": {
+                            "field": "uuid.keyword",
+                            "size": AGG_BUCKET_SIZE,
+                        },
+                        "aggs": {
+                            "profile": {
+                                "terms": {
+                                    "field": "profile.keyword",
+                                    "size": AGG_BUCKET_SIZE,
+                                },
+                                "aggs": {
+                                    "messageSize": {
+                                        "terms": {
+                                            "field": "messageSize",
+                                            "size": AGG_BUCKET_SIZE,
+                                        },
+                                        "aggs": {
+                                            "timestamp": {
+                                                "terms": {
+                                                    "field": "timestamp",
+                                                    "size": AGG_BUCKET_SIZE,
+                                                },
+                                                "aggs": {
+                                                    "throughput": {
+                                                        "avg": {
+                                                            "field": "throughput",
+                                                        }
+                                                    },
+                                                },
+                                            }
+                                        },
+                                    }
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        values = defaultdict(list)
+        graphs = []
+        print(
+            f"{self.benchmark} {version} {config} {variant} {len(uuids)} uuids ({len(response['aggregations']['uuid']['buckets'])} uuids)"
+        )
+        for uagg in response["aggregations"]["uuid"]["buckets"]:
+            uuid = uagg["key"]
+            for t in uagg["profile"]["buckets"]:
+                profile = t["key"]
+                for m in t["messageSize"]["buckets"]:
+                    key = f"{profile}-{m['key']:d}"
+                    for t in m["timestamp"]["buckets"]:
+                        values[key].append(
+                            {
+                                "uuid": uuid,
+                                "timestamp": t["key_as_string"],
+                                "value": t["throughput"]["value"],
+                            }
+                        )
+        for key, v in values.items():
+            v.sort(key=lambda v: v["timestamp"])
+            x = []
+            y = []
+            for point in v:
+                x.append(point["timestamp"])
+                y.append(point["value"])
+            graphs.append(
+                {
+                    "x": x,
+                    "y": y,
+                    "name": key,
+                    "type": "scatter",
+                    "mode": "lines+markers",
+                    "orientation": "v",
+                }
+            )
+        stats = response["aggregations"]["stats"]
+        sample = {
+            "values": values,
+            "graph": graphs,
+            "stats": {
+                "min": stats["min"],
+                "max": stats["max"],
+                "avg": stats["avg"],
+                "count": stats["count"],
+                "std_dev": stats["std_deviation"],
+            },
+        }
+        return sample
+
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Evaluate a metric sample for the primary "readiness" KPI.
+
+        This adds a "readiness" indicator to the metric sample, based on
+        defined thresholds.
+
+        *** WARNING ***
+
+        This is a dummy implementation based on trivial and arbitrary rules.
+
+        *** END WARNING ***
+
+        The benchmark is "not ready" if:
+
+        * If the final value is below the average value, the metric is "not
+          ready".
+
+        The metric can also be "warning" state if:
+
+        * If the standard deviation exceeds half the average value, the metric
+          is "warning".
+
+        Args:
+            metric: A dictionary containing the metric sample.
+
+        Returns:
+            "ready", "warning", or "not ready"
+        """
+        warning = 0
+        not_ready = 0
+        for key, value in metric["values"].items():
+            if len(value) < 2:
+                warning += 1
+            elif value[-1]["value"] < metric["stats"]["avg"]:
+                not_ready += 1
+        if metric["stats"]["std_dev"] > metric["stats"]["avg"] / 2:
+            warning += 1
+        return "not ready" if not_ready > 0 else "warning" if warning > 0 else "ready"
+
+
+class IngressPerfBenchmark(SearchBenchmark):
+
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, list[str]]:
+        return {"n/a": uuids}
+
+    async def process(
+        self, version: str, config: str, iter: int, uuids: list[str]
+    ) -> dict[str, Any]:
+        return {}
+
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Evaluate a metric sample for the primary "readiness" KPI.
+
+        This adds a "readiness" indicator to the metric sample, based on
+        defined thresholds.
+
+        This is a dummy implementation based on trivial and arbitrary rules.
+        The benchmark is "not ready" if:
+
+        * If the final value is below the average value, the metric is "not
+          ready".
+
+        The metric can also be "warning" state if:
+
+        * If the standard deviation exceeds half the average value, the metric
+          is "warning".
+
+        Args:
+            metric: A dictionary containing the metric sample.
+
+        Returns:
+            "ready", "warning", or "not ready"
+        """
+        if not metric:
+            print(f"{self.benchmark} evaluating empty metric")
+            return "warning"
+        if len(metric["values"]) < 2:
+            print(f"{self.benchmark} evaluating empty metric")
+            return "warning"
+        if metric["values"][-1]["value"] < metric["stats"]["avg"]:
+            return "not ready"
+        if metric["stats"]["std_dev"] > metric["stats"]["avg"] / 2:
+            return "warning"
+        return "ready"

--- a/backend/app/api/v1/endpoints/summary/summary.py
+++ b/backend/app/api/v1/endpoints/summary/summary.py
@@ -1,0 +1,214 @@
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, fields
+from typing import Any, Optional
+
+"""Information about product release CPT readiness.
+
+Each product version has a set of benchmarks that have been run for various
+system configurations. This data is recovered from the job index and used to
+access average and historical data for a product version to help assess
+product release readiness.
+
+NOTE: Other factors directly affecting release health include the health of the
+CI system, and any open Jira stories or bugs. Those factors aren't handled by
+this code.
+
+AI assistance: Cursor is extremely helpful in generating suggesting code
+snippets along the way. While most of this code is hand generated as the
+relationships are tricky and difficult to describe to the AI, it's been
+extremely helpful as an "over the shoulder assistant" to simplify routine
+coding tasks.
+
+Assisted-by: Cursor + claude-4-sonnet
+"""
+
+
+@dataclass
+class BaseFingerprint:
+
+    @classmethod
+    def parse(cls, node: dict[str, str]):
+        return cls(**node)
+
+    def key(self):
+        items = (
+            (f.metadata.get("str", f.name) + "=" + str(getattr(self, f.name)))
+            for f in fields(self)
+        )
+        k = ":".join(items)
+        return k
+
+    def json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def filter(cls):
+        f = [
+            {"term": {"field": f.name + (".keyword" if f.metadata.get("key") else "")}}
+            for f in fields(cls)
+        ]
+        return f
+
+    @classmethod
+    def composite(cls):
+        f = [
+            {
+                f.name: {
+                    "terms": {
+                        "field": f.name + (".keyword" if f.metadata.get("key") else "")
+                    }
+                }
+            }
+            for f in fields(cls)
+        ]
+        return f
+
+
+class Summary(ABC):
+    """Base class for summary services."""
+
+    product: str
+    configpath: str
+    version: list[str]
+    benchmarks: list[str]
+    start_date: str | None
+    end_date: str | None
+    date_filter: dict[str, Any] | None
+    service: Any = None
+
+    @staticmethod
+    def break_list(value: str | list[str] | None) -> list[str]:
+        all = []
+        if isinstance(value, str):
+            all.extend(value.split(","))
+        elif isinstance(value, list):
+            for v in value:
+                all.extend(v.split(","))
+        return all
+
+    def __init__(
+        self,
+        product: str,
+        configpath: str = "ocp.elasticsearch",
+    ):
+        self.product = product
+        self.configpath = configpath
+        self.start_date = None
+        self.end_date = None
+        self.date_filter = None
+        self.service = None
+
+    @abstractmethod
+    def set_date_filter(self, start_date: str | None, end_date: str | None):
+        """Set the date filter for the summary service."""
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def close(self):
+        """Close the summary service."""
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def get_versions(self) -> dict[str, list[str]]:
+        """Return a list of versions.
+
+        This must be implemented by the subclass.
+
+        Returns:
+            The full version strings for each "short version" (e.g. "4.19").
+        """
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def get_benchmarks(self, version: str) -> dict[str, Any]:
+        """Return a list of benchmarks run for a given product version.
+
+        This must be implemented by the subclass.
+
+        Args:
+            version: The product version to get benchmarks for.
+
+        Returns:
+            A list of benchmarks and the configurations for which each is run.
+        """
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def get_iterations(
+        self,
+        versions: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Break down our benchmark configuration data.
+
+        This must be implemented by the subclass.
+
+        This function identifies the set of jobs that can be compared based on
+        identical configuration and iteration count.
+        """
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def get_configs(
+        self, versions: Optional[str] = None, benchmarks: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Return report the configurations for which each benchmar was run.
+
+        This must be implemented by the subclass.
+
+        Args:
+            versions: The OCP versions to get configurations for.
+            benchmarks: The benchmarks to get configurations for.
+        """
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    async def metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Report aggregated metrics for each benchmark configuration.
+
+        For each selected version, benchmark, configuration, report on the
+        primary "readiness" KPI. The results include a list of individual
+        timestamped values, a statistical summary, and a Plotly-formatted
+        graph of the individual runs.
+
+        This must be implemented by a subclass.
+
+        Args:
+            versions: Select only the named versions (comma-separated list)
+            benchmarks: Select only the named benchmarks (comma-separated list)
+            configs: Select only the named configurations (comma-separated list)
+
+        """
+        raise NotImplementedError("Not implemented")
+
+
+class BenchmarkBase(ABC):
+    summary: "Summary"
+    benchmark: str
+
+    def __init__(self, summary: Summary, benchmark: str):
+        self.benchmark = benchmark
+        self.summary = summary
+
+    @abstractmethod
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, list[str]]:
+        """Get the iteration variants for a list of UUIDs."""
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    async def process(
+        self, version: str, config: str, iter: Any, uuids: list[str]
+    ) -> dict[str, Any]:
+        """Process a list of UUIDs."""
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Evaluate a sample."""
+        raise NotImplementedError("Subclasses must implement this method")

--- a/backend/app/api/v1/endpoints/summary/summary_api.py
+++ b/backend/app/api/v1/endpoints/summary/summary_api.py
@@ -1,0 +1,210 @@
+import asyncio
+from dataclasses import dataclass
+import traceback
+from typing import Annotated, Any, Callable, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.v1.endpoints.ocp.summary import OcpSummary
+from app.api.v1.endpoints.summary.summary import Summary
+
+router = APIRouter()
+
+"""Access product "release readiness" summary data.
+
+AI assistance: Cursor is extremely insistant on generating suggested code
+snippets along the way, some of which are annoyingly stupid and surprizingly
+many of which are remarkably insightful. While most of this code is hand
+generated as the relationships are tricky and difficult to describe to the AI,
+Cursor has been extremely helpful as an "over the shoulder assistant" to
+simplify routine coding tasks. (It excels at recognizing repeated change
+patterns during refactoring, for example.)
+
+Assisted-by: Cursor + claude-4-sonnet
+"""
+
+router = APIRouter()
+
+
+@dataclass
+class Product:
+    summaryclass: type[Summary]
+    configpath: str
+
+
+@dataclass
+class ProductContext:
+    product: str
+    instance: Summary
+
+
+@dataclass
+class ProductResults:
+    product: str
+    results: dict[str, Any]
+
+
+PRODUCTS = {
+    "ocp": Product(OcpSummary, "ocp.elasticsearch"),
+}
+
+
+def create(product: str) -> "Summary":
+    """Create a summary service for a given product."""
+    if product in PRODUCTS:
+        c = PRODUCTS[product]
+        return c.summaryclass(product, c.configpath)
+    raise NotImplementedError("Not implemented")
+
+
+async def summary_svc(products: str | None = None) -> dict[str, ProductContext]:
+    """FastAPI Dependency to open & close ElasticService connections"""
+    summaries: dict[str, ProductContext] = {}
+    ps = Summary.break_list(products) if products else list(PRODUCTS.keys())
+    try:
+        summaries = {
+            product: ProductContext(product, create(product)) for product in ps
+        }
+        yield summaries
+    except Exception as e:
+        print(f"Error opening {products} summary service: {e}")
+        raise HTTPException(
+            status_code=400, detail=f"Product {products} can't be opened: {str(e)!r}"
+        )
+    finally:
+        if summaries:
+            await asyncio.gather(
+                *[summary.instance.close() for summary in summaries.values()]
+            )
+
+
+async def collect(
+    products: str | None,
+    context: dict[str, ProductContext],
+    method: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Launch multiple product queries concurrently and collect results
+
+    Args:
+        products: The products to get versions for (comma separated list)
+        context: A dictionary of summary services for each product
+        method: Name of the Summary class method to call
+        start_date: The start date to filter the versions by
+        end_date: The end date to filter the versions by
+    """
+    results = {}
+    try:
+        for p in Summary.break_list(products) if products else PRODUCTS.keys():
+            c = context[p]
+            summary = c.instance
+            m = getattr(summary, method)
+            if not isinstance(m, Callable):
+                raise ValueError(f"{p} {method} is not callable")
+            print(f"collect {method}: {start_date} - {end_date}")
+            summary.set_date_filter(start_date, end_date)
+            results[p] = m(**kwargs)
+        ret = {}
+        for name, result in results.items():
+            ret[name] = await result
+    except Exception as e:
+        print(f"Error collecting {p} {method}: {e}")
+        print(traceback.format_exc())
+    return ret
+
+
+@router.get("/api/v1/summary/products")
+async def products() -> list[str]:
+    """Return a list of products that have testing data."""
+    return list(PRODUCTS.keys())
+
+
+@router.get("/api/v1/summary/versions")
+async def versions(
+    summaries: Annotated[dict[str, ProductContext], Depends(summary_svc)],
+    products: str | None = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict[str, dict[str, list[str]]]:
+    """Return a list of versions that have been tested
+
+    This report can be filtered to a date range.
+
+    Args:
+        summaries: A dictionary of summary services for each product
+        products: The products to get versions for (comma separated list)
+        start_date: The start date to filter the versions by
+        end_date: The end date to filter the versions by
+    """
+    return await collect(
+        products, summaries, "get_versions", start_date=start_date, end_date=end_date
+    )
+
+
+@router.get("/api/v1/summary/benchmarks")
+async def configs(
+    summaries: Annotated[Summary, Depends(summary_svc)],
+    products: str | None = None,
+    versions: Optional[str] = None,
+    benchmarks: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    uuids: Optional[bool] = False,
+) -> dict[str, Any]:
+    """Return a list of benchmarks that have been tested
+
+    This report can be filtered to a date range.
+
+    Args:
+        summaries: A dictionary of summary services for each product
+        products: The products to get benchmarks for (comma separated list)
+        versions: The versions to get benchmarks for (comma separated list)
+        benchmarks: The benchmarks to get details for (comma separated list)
+        start_date: The start date to filter the benchmarks by
+        end_date: The end date to filter the benchmarks by
+    """
+    return await collect(
+        products,
+        summaries,
+        "get_configs",
+        start_date=start_date,
+        end_date=end_date,
+        versions=versions,
+        benchmarks=benchmarks,
+        uuids=uuids,
+    )
+
+
+@router.get("/api/v1/summary")
+async def summary(
+    summaries: Annotated[Summary, Depends(summary_svc)],
+    products: str | None = None,
+    versions: Optional[str] = None,
+    benchmarks: Optional[str] = None,
+    configs: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict[str, Any]:
+    """Generate statistical summary data
+
+    Args:
+        summaries: A dictionary of summary services for each product
+        products: The products to get benchmarks for (comma separated list)
+        versions: The versions to get benchmarks for (comma separated list)
+        benchmarks: The benchmarks to get details for (comma separated list)
+        configs: The specific configuration(s) to find (comma separated list)
+        start_date: The start date to filter the benchmarks by
+        end_date: The end date to filter the benchmarks by
+    """
+    return await collect(
+        products,
+        summaries,
+        "metric_aggregation",
+        start_date=start_date,
+        end_date=end_date,
+        versions=versions,
+        benchmarks=benchmarks,
+        configs=configs,
+    )

--- a/backend/app/api/v1/endpoints/summary/summary_search.py
+++ b/backend/app/api/v1/endpoints/summary/summary_search.py
@@ -1,0 +1,125 @@
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.api.v1.endpoints.summary.summary import BaseFingerprint, BenchmarkBase, Summary
+from app.services.search import ElasticService
+
+"""CPT summary information for benchmarks using ElasticService.
+
+This is a subclass of the Summary class targeted to products using the
+ElasticService class to access OpenSearch data.
+
+AI assistance: Cursor is extremely helpful in generating suggesting code
+snippets along the way. While most of this code is hand generated as the
+relationships are tricky and difficult to describe to the AI, it's been
+extremely helpful as an "over the shoulder assistant" to simplify routine
+coding tasks.
+
+Assisted-by: Cursor + claude-4-sonnet
+"""
+
+
+@dataclass
+class Benchmark:
+    """Map each benchmark to an index and ElasticService filter.
+
+    TODO: Some benchmarks have multiple indices, e.g. quay-load-test. We need
+    to handle this case.
+    """
+
+    index: str
+    filter: dict[str, str] | None = None
+
+
+@dataclass
+class PerfCiFingerprint(BaseFingerprint):
+    """Extend the BaseFingerprint class with OCP-specific fields."""
+
+    masterNodesType: str = field(metadata={"str": "mt", "key": True})
+    masterNodesCount: int = field(metadata={"str": "mc"})
+    workerNodesType: str = field(metadata={"str": "wt", "key": True})
+    workerNodesCount: int = field(metadata={"str": "wc"})
+
+
+class SummarySearch(Summary):
+    """Summary subclass for benchmarks using ElasticService."""
+
+    service: ElasticService = None
+    date_filter: dict[str, Any] | None
+    benchmarks: dict[str, Benchmark]
+    benchmark_helper: dict[str, "BenchmarkBase"]
+
+    def __init__(
+        self,
+        product: str,
+        configpath: str = "ocp.elasticsearch",
+        benchmarks: dict[str, Benchmark] | None = None,
+    ):
+        super().__init__(product, configpath)
+        print(f"opening ElasticService ({configpath})")
+        self.service = ElasticService(configpath)
+        self.date_filter = None
+        self.benchmarks = benchmarks or {}
+        self.benchmark_helper = {}
+
+    def get_index(self, benchmark: str) -> str | None:
+        """Get the index associated with a benchmark."""
+        b = self.benchmarks.get(benchmark)
+        return b.index if b else None
+
+    def get_filter(self, benchmark: str) -> dict[str, str] | None:
+        """Get the filter associated with a benchmark."""
+        b = self.benchmarks.get(benchmark)
+        return b.filter if b else None
+
+    def get_helper(self, benchmark: str) -> "BenchmarkBase":
+        """Get a benchmark helper class instance for a benchmark."""
+        helper = self.benchmark_helper.get(benchmark)
+        if not helper:
+            print(f"creating helper for benchmark {benchmark}")
+            helper = self.create_helper(benchmark)
+            self.benchmark_helper[benchmark] = helper
+        return helper
+
+    @abstractmethod
+    def create_helper(self, benchmark: str) -> "BenchmarkBase":
+        """Create an instance of the helper class for a benchmark."""
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def set_date_filter(self, start_date: str | None, end_date: str | None):
+        """Create a date filter dict for a given start and end date."""
+        if start_date or end_date:
+            self.end_date = end_date
+            self.date_filter = None
+            range = {"format": "yyyy-MM-dd"}
+            if start_date:
+                range["gte"] = start_date
+            if end_date:
+                range["lte"] = end_date
+            self.date_filter = {
+                "range": {
+                    "timestamp": range,
+                }
+            }
+        else:
+            self.date_filter = None
+
+    @abstractmethod
+    async def close(self):
+        """Close the summary service."""
+        print(f"closing {type(self.service).__name__}")
+        await self.service.close()
+
+
+class SearchBenchmark(BenchmarkBase):
+    """BenchmarkBase subclass for benchmarks using ElasticService."""
+
+    summary: Summary
+    benchmark: str
+    index: str | None = None
+
+    def __init__(self, summary: Summary, benchmark: str):
+        """Initialize the SearchBenchmark instance."""
+        super().__init__(summary, benchmark)
+        self.index = summary.get_index(benchmark)

--- a/backend/tests/unit/test_ocp_summary.py
+++ b/backend/tests/unit/test_ocp_summary.py
@@ -1,0 +1,1665 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.v1.endpoints.ocp.summary import (
+    BENCHMARK_INDEX,
+    IngressPerfBenchmark,
+    K8sNetperfBenchmark,
+    KubeBurnerBenchmark,
+    OcpFingerprint,
+    OcpSummary,
+)
+from app.api.v1.endpoints.summary.summary_search import Benchmark
+
+"""Unit tests for the OCP summary module.
+
+This file tests the classes and functionality defined in ocp/summary.py,
+including OcpFingerprint, OcpSummary, KubeBurnerBenchmark, K8sNetperfBenchmark,
+and IngressPerfBenchmark classes.
+
+Follows established patterns from other unit tests with Given-When-Then structure.
+
+Generated-by: Cursor
+"""
+
+
+@pytest.fixture
+def mock_elastic_service():
+    """Create a mock ElasticService for testing."""
+    mock_service = AsyncMock()
+    mock_service.close = AsyncMock()
+    mock_service.post = AsyncMock()
+    return mock_service
+
+
+@pytest.fixture
+def mock_ocp_summary(mock_elastic_service, monkeypatch):
+    """Create a mock OcpSummary instance with mocked ElasticService."""
+
+    # Patch ElasticService at the import location
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.summary.summary_search.ElasticService",
+        lambda configpath: mock_elastic_service,
+    )
+
+    summary = OcpSummary("ocp", "ocp.elasticsearch")
+    return summary
+
+
+class TestBenchmarkIndex:
+    """Test cases for BENCHMARK_INDEX constant."""
+
+    def test_benchmark_index_structure(self):
+        """Test that BENCHMARK_INDEX has expected structure."""
+        # Given: The BENCHMARK_INDEX constant
+        # When: Checking its structure
+        # Then: It should be a dictionary with string keys
+        assert isinstance(BENCHMARK_INDEX, dict)
+        assert all(isinstance(k, str) for k in BENCHMARK_INDEX.keys())
+
+    def test_benchmark_index_contains_expected_benchmarks(self):
+        """Test that BENCHMARK_INDEX contains known benchmarks."""
+        # Given: Known benchmark names
+        known_benchmarks = [
+            "cluster-density",
+            "cluster-density-v2",
+            "k8s-netperf",
+            "ingress-perf",
+            "virt-density",
+            "olm",
+        ]
+
+        # When: Checking if they exist in BENCHMARK_INDEX
+        # Then: All known benchmarks should be present
+        for benchmark in known_benchmarks:
+            assert benchmark in BENCHMARK_INDEX
+
+    def test_benchmark_index_cluster_density(self):
+        """Test cluster-density benchmark configuration."""
+        # Given: The cluster-density benchmark
+        benchmark = BENCHMARK_INDEX["cluster-density"]
+
+        # When: Checking its properties
+        # Then: It should have correct index and filter
+        assert isinstance(benchmark, Benchmark)
+        assert benchmark.index == "ripsaw-kube-burner"
+        assert benchmark.filter == {
+            "metricName.keyword": "podLatencyQuantilesMeasurement",
+            "quantileName.keyword": "Ready",
+        }
+
+    def test_benchmark_index_k8s_netperf(self):
+        """Test k8s-netperf benchmark configuration."""
+        # Given: The k8s-netperf benchmark
+        benchmark = BENCHMARK_INDEX["k8s-netperf"]
+
+        # When: Checking its properties
+        # Then: It should have correct index with no filter
+        assert isinstance(benchmark, Benchmark)
+        assert benchmark.index == "k8s-netperf"
+        assert benchmark.filter is None
+
+    def test_benchmark_index_none_values(self):
+        """Test that some benchmarks have None values."""
+        # Given: Benchmarks that should not have configurations
+        none_benchmarks = ["custom", "index", "node-density", "concurrent-builds"]
+
+        # When: Checking their values
+        # Then: They should be None
+        for benchmark in none_benchmarks:
+            assert BENCHMARK_INDEX[benchmark] is None
+
+
+class TestOcpFingerprint:
+    """Test cases for OcpFingerprint dataclass."""
+
+    def test_ocp_fingerprint_creation(self):
+        """Test creating an OcpFingerprint instance."""
+        # Given: Fingerprint parameters (only fields that exist in OcpFingerprint)
+        # When: Creating an OcpFingerprint
+        fingerprint = OcpFingerprint(
+            platform="aws",
+            masterNodesType="m5.xlarge",
+            masterNodesCount=3,
+            workerNodesType="m5.2xlarge",
+            workerNodesCount=120,
+        )
+
+        # Then: All fields should be set correctly
+        assert fingerprint.platform == "aws"
+        assert fingerprint.masterNodesType == "m5.xlarge"
+        assert fingerprint.masterNodesCount == 3
+        assert fingerprint.workerNodesType == "m5.2xlarge"
+        assert fingerprint.workerNodesCount == 120
+
+    def test_ocp_fingerprint_metadata(self):
+        """Test OcpFingerprint metadata for platform field."""
+        # Given: OcpFingerprint class
+        # When: Checking platform field metadata
+        field_info = OcpFingerprint.__dataclass_fields__["platform"]
+
+        # Then: Should have correct metadata
+        assert field_info.metadata["str"] == "p"
+        assert field_info.metadata["key"] is True
+
+
+class TestOcpSummary:
+    """Test cases for OcpSummary class."""
+
+    def test_init(self, mock_ocp_summary):
+        """Test OcpSummary initialization."""
+        # Given: A mock OcpSummary instance from fixture
+        summary = mock_ocp_summary
+
+        # When/Then: Should be initialized correctly
+        assert summary.product == "ocp"
+        assert summary.configpath == "ocp.elasticsearch"
+        assert summary.service is not None
+        assert summary.benchmarks == BENCHMARK_INDEX
+
+    def test_create_helper_kube_burner(self, mock_ocp_summary):
+        """Test create_helper returns KubeBurnerBenchmark for ripsaw-kube-burner."""
+        # Given: An OcpSummary instance and a kube-burner benchmark
+        benchmark = "cluster-density"
+
+        # When: Creating a helper
+        helper = mock_ocp_summary.create_helper(benchmark)
+
+        # Then: Should return KubeBurnerBenchmark instance
+        assert isinstance(helper, KubeBurnerBenchmark)
+        assert helper.benchmark == benchmark
+
+    def test_create_helper_k8s_netperf(self, mock_ocp_summary):
+        """Test create_helper returns K8sNetperfBenchmark for k8s-netperf."""
+        # Given: An OcpSummary instance and k8s-netperf benchmark
+        benchmark = "k8s-netperf"
+
+        # When: Creating a helper
+        helper = mock_ocp_summary.create_helper(benchmark)
+
+        # Then: Should return K8sNetperfBenchmark instance
+        assert isinstance(helper, K8sNetperfBenchmark)
+        assert helper.benchmark == benchmark
+
+    def test_create_helper_ingress_perf(self, mock_ocp_summary):
+        """Test create_helper returns IngressPerfBenchmark for ingress-performance."""
+        # Given: An OcpSummary instance and ingress-perf benchmark
+        benchmark = "ingress-perf"
+
+        # When: Creating a helper
+        helper = mock_ocp_summary.create_helper(benchmark)
+
+        # Then: Should return IngressPerfBenchmark instance
+        assert isinstance(helper, IngressPerfBenchmark)
+        assert helper.benchmark == benchmark
+
+    def test_create_helper_unsupported_benchmark(self, mock_ocp_summary):
+        """Test create_helper raises ValueError for unsupported benchmarks."""
+        # Given: An OcpSummary instance and unsupported benchmark
+        benchmark = "node-density"  # Has None value in BENCHMARK_INDEX
+
+        # When/Then: Should raise ValueError
+        with pytest.raises(ValueError, match="Unsupported benchmark"):
+            mock_ocp_summary.create_helper(benchmark)
+
+    @pytest.mark.asyncio
+    async def test_get_versions(self, mock_ocp_summary, mock_elastic_service):
+        """Test get_versions returns properly formatted version data."""
+        # Given: Mock response from ElasticService
+        mock_elastic_service.post.return_value = {
+            "aggregations": {
+                "versions": {
+                    "buckets": [
+                        {"key": "4.18.0-nightly"},
+                        {"key": "4.18.1-nightly"},
+                        {"key": "4.19.0-nightly"},
+                        {"key": "4.19.1-nightly"},
+                        {"key": "4.20.0-rc1"},
+                    ]
+                }
+            }
+        }
+
+        # When: Getting versions
+        versions = await mock_ocp_summary.get_versions()
+
+        # Then: Versions should be grouped by short version
+        assert "4.18" in versions
+        assert "4.19" in versions
+        assert "4.20" in versions
+        assert "4.18.0-nightly" in versions["4.18"]
+        assert "4.18.1-nightly" in versions["4.18"]
+        assert "4.19.0-nightly" in versions["4.19"]
+        assert "4.20.0-rc1" in versions["4.20"]
+
+        # Check that post was called with correct query structure
+        mock_elastic_service.post.assert_called_once()
+        # Get the call kwargs (keyword arguments)
+        call_kwargs = mock_elastic_service.post.call_args.kwargs
+        # The 'query' parameter contains the entire query dict
+        assert "query" in call_kwargs
+        query_dict = call_kwargs["query"]
+        assert "query" in query_dict
+        assert "bool" in query_dict["query"]
+        assert "filter" in query_dict["query"]["bool"]
+        assert {"match": {"jobStatus": "success"}} in query_dict["query"]["bool"][
+            "filter"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_versions_with_date_filter(
+        self, mock_ocp_summary, mock_elastic_service
+    ):
+        """Test get_versions applies date filter when set."""
+        # Given: OcpSummary with date filter
+        mock_ocp_summary.date_filter = {
+            "range": {"timestamp": {"gte": "2024-01-01", "lte": "2024-12-31"}}
+        }
+        mock_elastic_service.post.return_value = {
+            "aggregations": {"versions": {"buckets": [{"key": "4.18.0-nightly"}]}}
+        }
+
+        # When: Getting versions
+        await mock_ocp_summary.get_versions()
+
+        # Then: Date filter should be in query
+        call_kwargs = mock_elastic_service.post.call_args.kwargs
+        query_dict = call_kwargs["query"]
+        assert "query" in query_dict
+        assert mock_ocp_summary.date_filter in query_dict["query"]["bool"]["filter"]
+
+    @pytest.mark.asyncio
+    async def test_get_benchmarks(self, mock_ocp_summary, mock_elastic_service):
+        """Test get_benchmarks returns benchmark hierarchy."""
+        # Given: Mock response with benchmark and configuration data
+        mock_elastic_service.post.return_value = {
+            "aggregations": {
+                "configurations": {
+                    "buckets": [
+                        {
+                            "key": {
+                                "platform": "aws",
+                                "masterNodesType": "m5.xlarge",
+                                "masterNodesCount": 3,
+                                "workerNodesType": "m5.2xlarge",
+                                "workerNodesCount": 120,
+                            },
+                            "benchmarks": {
+                                "buckets": [
+                                    {
+                                        "key": "cluster-density",
+                                        "uuids": {
+                                            "buckets": [
+                                                {"key": "uuid-1"},
+                                                {"key": "uuid-2"},
+                                            ]
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+
+        # When: Getting benchmarks
+        benchmarks = await mock_ocp_summary.get_benchmarks("4.18")
+
+        # Then: Should return properly structured benchmark data
+        assert "cluster-density" in benchmarks
+        assert len(benchmarks["cluster-density"]) > 0
+        config = benchmarks["cluster-density"][0]
+        assert "configuration" in config
+        assert "uuids" in config
+        assert len(config["uuids"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_no_filters(
+        self, mock_ocp_summary, mock_elastic_service
+    ):
+        """Test get_iterations with no version/benchmark filters."""
+        # Given: Mock responses for get_versions and get_benchmarks
+        mock_elastic_service.post.side_effect = [
+            # get_versions response
+            {
+                "aggregations": {
+                    "versions": {
+                        "buckets": [
+                            {"key": "4.18.0-nightly"},
+                            {"key": "4.19.0-nightly"},
+                        ]
+                    }
+                }
+            },
+            # get_benchmarks response for 4.18
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                    {"key": "uuid-2"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {
+                                    "buckets": [
+                                        {"key": "uuid-1"},
+                                        {"key": "uuid-2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_benchmarks response for 4.19
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "k8s-netperf",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-3"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants for k8s-netperf (returns n/a)
+            {},
+        ]
+
+        # When: Getting iterations
+        iterations = await mock_ocp_summary.get_iterations()
+
+        # Then: Should return structured iteration data
+        assert "config_key" in iterations
+        assert "benchmarks" in iterations
+        assert "4.18" in iterations["benchmarks"]
+        assert "cluster-density" in iterations["benchmarks"]["4.18"]
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_with_filters(
+        self, mock_ocp_summary, mock_elastic_service
+    ):
+        """Test get_iterations with version and benchmark filters."""
+        # Given: Specific version and benchmark filters
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {"buckets": [{"key": "uuid-1"}]},
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # When: Getting iterations with filters
+        iterations = await mock_ocp_summary.get_iterations(
+            versions="4.18", benchmarks="cluster-density"
+        )
+
+        # Then: Should return filtered data
+        assert "benchmarks" in iterations
+        assert "4.18" in iterations["benchmarks"]
+        assert "cluster-density" in iterations["benchmarks"]["4.18"]
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_no_variants(
+        self, mock_ocp_summary, mock_elastic_service
+    ):
+        """Test get_iterations when no variants are found."""
+        # Given: Mock responses with no iteration variants
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response (empty)
+            {"aggregations": {"jobIterations": {"buckets": []}}},
+        ]
+
+        # When: Getting iterations
+        iterations = await mock_ocp_summary.get_iterations(versions="4.18")
+
+        # Then: Should return empty benchmark data
+        assert "benchmarks" in iterations
+        if "4.18" in iterations["benchmarks"]:
+            if "cluster-density" in iterations["benchmarks"]["4.18"]:
+                config_keys = list(
+                    iterations["benchmarks"]["4.18"]["cluster-density"].keys()
+                )
+                if config_keys:
+                    assert (
+                        iterations["benchmarks"]["4.18"]["cluster-density"][
+                            config_keys[0]
+                        ]
+                        == {}
+                    )
+
+    @pytest.mark.asyncio
+    async def test_get_configs(self, mock_ocp_summary, mock_elastic_service):
+        """Test get_configs returns iteration counts."""
+        # Given: Mock iteration data
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                    {"key": "uuid-2"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {
+                                    "buckets": [
+                                        {"key": "uuid-1"},
+                                        {"key": "uuid-2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # When: Getting configs (counts, not uuids)
+        configs = await mock_ocp_summary.get_configs(
+            versions="4.18", benchmarks="cluster-density", uuids=False
+        )
+
+        # Then: Should return counts instead of uuid lists
+        assert "config_key" in configs
+        assert "benchmarks" in configs
+        if "4.18" in configs["benchmarks"]:
+            if "cluster-density" in configs["benchmarks"]["4.18"]:
+                config_keys = list(
+                    configs["benchmarks"]["4.18"]["cluster-density"].keys()
+                )
+                if config_keys:
+                    first_config = configs["benchmarks"]["4.18"]["cluster-density"][
+                        config_keys[0]
+                    ]
+                    if first_config:
+                        for count in first_config.values():
+                            assert isinstance(count, int)
+
+    @pytest.mark.asyncio
+    async def test_get_configs_with_uuids(self, mock_ocp_summary, mock_elastic_service):
+        """Test get_configs returns uuid lists when requested."""
+        # Given: Mock iteration data
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                    {"key": "uuid-2"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {
+                                    "buckets": [
+                                        {"key": "uuid-1"},
+                                        {"key": "uuid-2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # When: Getting configs with uuids=True
+        configs = await mock_ocp_summary.get_configs(
+            versions="4.18", benchmarks="cluster-density", uuids=True
+        )
+
+        # Then: Should return uuid lists
+        assert "config_key" in configs
+        assert "benchmarks" in configs
+
+    def test_is_ready_not_ready(self, mock_ocp_summary):
+        """Test is_ready returns 'not ready' when not ready is in set."""
+        # Given: A readiness set with 'not ready'
+        readiness = {"ready", "warning", "not ready"}
+
+        # When: Checking readiness
+        result = mock_ocp_summary.is_ready(readiness)
+
+        # Then: Should return 'not ready'
+        assert result == "not ready"
+
+    def test_is_ready_warning(self, mock_ocp_summary):
+        """Test is_ready returns 'warning' when only warning and ready."""
+        # Given: A readiness set with 'warning'
+        readiness = {"ready", "warning"}
+
+        # When: Checking readiness
+        result = mock_ocp_summary.is_ready(readiness)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+    def test_is_ready_ready(self, mock_ocp_summary):
+        """Test is_ready returns 'ready' when only ready."""
+        # Given: A readiness set with only 'ready'
+        readiness = {"ready"}
+
+        # When: Checking readiness
+        result = mock_ocp_summary.is_ready(readiness)
+
+        # Then: Should return 'ready'
+        assert result == "ready"
+
+    @pytest.mark.asyncio
+    async def test_metric_aggregation(self, mock_ocp_summary, mock_elastic_service):
+        """Test metric_aggregation aggregates metrics across configurations."""
+        # Given: Mock responses for iterations and processing
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                    {"key": "uuid-2"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {
+                                    "buckets": [
+                                        {"key": "uuid-1"},
+                                        {"key": "uuid-2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # process response (KubeBurnerBenchmark)
+            {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "uuid": "uuid-1",
+                                "timestamp": "2024-01-15T10:00:00Z",
+                                "P99": 1000,
+                            }
+                        },
+                        {
+                            "_source": {
+                                "uuid": "uuid-2",
+                                "timestamp": "2024-01-15T11:00:00Z",
+                                "P99": 1500,
+                            }
+                        },
+                    ]
+                },
+                "aggregations": {
+                    "stats": {
+                        "min": 1000,
+                        "max": 1500,
+                        "avg": 1250,
+                        "std_deviation": 250,
+                    }
+                },
+            },
+        ]
+
+        # When: Getting metric aggregation
+        result = await mock_ocp_summary.metric_aggregation(
+            versions="4.18", benchmarks="cluster-density"
+        )
+
+        # Then: Should return aggregated metrics
+        assert "config_key" in result
+        assert "versions" in result
+        assert "readiness" in result
+        assert result["readiness"] in ["ready", "warning", "not ready"]
+
+    @pytest.mark.asyncio
+    async def test_metric_aggregation_unsupported_benchmark(
+        self, mock_ocp_summary, mock_elastic_service
+    ):
+        """Test metric_aggregation handles unsupported benchmarks gracefully."""
+        # Given: Mock responses with unsupported benchmark
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response with unsupported benchmark
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "custom",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # When: Getting metric aggregation
+        result = await mock_ocp_summary.metric_aggregation(versions="4.18")
+
+        # Then: Should handle gracefully and return result
+        assert "versions" in result
+        assert "readiness" in result
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_with_value_error(
+        self, mock_ocp_summary, mock_elastic_service, monkeypatch
+    ):
+        """Test get_iterations handles ValueError from get_helper gracefully."""
+        # Given: Mock responses and get_helper that raises ValueError
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # Mock get_helper to raise ValueError
+        def mock_get_helper(benchmark):
+            raise ValueError(f"Unsupported benchmark: {benchmark}")
+
+        monkeypatch.setattr(mock_ocp_summary, "get_helper", mock_get_helper)
+
+        # When: Getting iterations
+        iterations = await mock_ocp_summary.get_iterations(versions="4.18")
+
+        # Then: Should handle gracefully and return empty metrics for that benchmark
+        assert "benchmarks" in iterations
+        assert "4.18" in iterations["benchmarks"]
+        assert "cluster-density" in iterations["benchmarks"]["4.18"]
+        # The benchmark should have empty config due to ValueError
+        config_keys = list(iterations["benchmarks"]["4.18"]["cluster-density"].keys())
+        if config_keys:
+            assert (
+                iterations["benchmarks"]["4.18"]["cluster-density"][config_keys[0]]
+                == {}
+            )
+
+    @pytest.mark.asyncio
+    async def test_metric_aggregation_with_value_error(
+        self, mock_ocp_summary, mock_elastic_service, monkeypatch
+    ):
+        """Test metric_aggregation handles ValueError from get_helper gracefully."""
+        # Given: Mock responses with benchmark data
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            # get_iteration_variants response
+            {
+                "aggregations": {
+                    "jobIterations": {
+                        "buckets": [
+                            {
+                                "key": 100,
+                                "uuids": {"buckets": [{"key": "uuid-1"}]},
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # Mock get_helper to raise ValueError
+        def mock_get_helper(benchmark):
+            raise ValueError(f"Benchmark {benchmark} not supported")
+
+        monkeypatch.setattr(mock_ocp_summary, "get_helper", mock_get_helper)
+
+        # When: Getting metric aggregation
+        result = await mock_ocp_summary.metric_aggregation(versions="4.18")
+
+        # Then: Should handle gracefully and skip the unsupported benchmark
+        assert "versions" in result
+        assert "readiness" in result
+        # The version should exist but benchmarks should be empty or not include the failed one
+        if "4.18" in result["versions"]:
+            assert "benchmarks" in result["versions"]["4.18"]
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_empty_variants(
+        self, mock_ocp_summary, mock_elastic_service, monkeypatch
+    ):
+        """Test get_iterations handles empty variants gracefully."""
+        # Given: Mock responses where get_iteration_variants returns empty
+        mock_elastic_service.post.side_effect = [
+            # get_benchmarks response
+            {
+                "aggregations": {
+                    "configurations": {
+                        "buckets": [
+                            {
+                                "key": {
+                                    "platform": "aws",
+                                    "masterNodesType": "m5.xlarge",
+                                    "masterNodesCount": 3,
+                                    "workerNodesType": "m5.2xlarge",
+                                    "workerNodesCount": 120,
+                                },
+                                "benchmarks": {
+                                    "buckets": [
+                                        {
+                                            "key": "cluster-density",
+                                            "uuids": {
+                                                "buckets": [
+                                                    {"key": "uuid-1"},
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+
+        # Create a real helper but mock its get_iteration_variants to return empty dict
+        original_create_helper = mock_ocp_summary.create_helper
+
+        def mock_create_helper(benchmark):
+            helper = original_create_helper(benchmark)
+
+            # Mock the get_iteration_variants method to return empty dict
+            async def empty_variants(index, uuids):
+                return {}
+
+            helper.get_iteration_variants = empty_variants
+            return helper
+
+        monkeypatch.setattr(mock_ocp_summary, "create_helper", mock_create_helper)
+
+        # When: Getting iterations
+        iterations = await mock_ocp_summary.get_iterations(versions="4.18")
+
+        # Then: Should handle gracefully and return empty metrics for that config
+        assert "benchmarks" in iterations
+        assert "4.18" in iterations["benchmarks"]
+        assert "cluster-density" in iterations["benchmarks"]["4.18"]
+        # The benchmark should have empty config due to empty variants
+        config_keys = list(iterations["benchmarks"]["4.18"]["cluster-density"].keys())
+        if config_keys:
+            assert (
+                iterations["benchmarks"]["4.18"]["cluster-density"][config_keys[0]]
+                == {}
+            )
+
+
+class TestKubeBurnerBenchmark:
+    """Test cases for KubeBurnerBenchmark class."""
+
+    @pytest.fixture
+    def kube_burner_benchmark(self, mock_ocp_summary):
+        """Create a KubeBurnerBenchmark instance for testing."""
+        return KubeBurnerBenchmark(mock_ocp_summary, "cluster-density")
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants(
+        self, kube_burner_benchmark, mock_elastic_service
+    ):
+        """Test get_iteration_variants returns iteration variants."""
+        # Given: Mock response with iteration data
+        mock_elastic_service.post.return_value = {
+            "aggregations": {
+                "jobIterations": {
+                    "buckets": [
+                        {
+                            "key": 100,
+                            "uuids": {
+                                "buckets": [
+                                    {"key": "uuid-1"},
+                                    {"key": "uuid-2"},
+                                ]
+                            },
+                        },
+                        {
+                            "key": 200,
+                            "uuids": {
+                                "buckets": [
+                                    {"key": "uuid-3"},
+                                ]
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        # When: Getting iteration variants
+        variants = await kube_burner_benchmark.get_iteration_variants(
+            "ripsaw-kube-burner", ["uuid-1", "uuid-2", "uuid-3"]
+        )
+
+        # Then: Should return variants grouped by iteration count
+        assert 100 in variants
+        assert 200 in variants
+        assert "uuid-1" in variants[100]
+        assert "uuid-2" in variants[100]
+        assert "uuid-3" in variants[200]
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants_with_date_filter(
+        self, kube_burner_benchmark, mock_elastic_service, mock_ocp_summary
+    ):
+        """Test get_iteration_variants applies date filter when set."""
+        # Given: Mock summary with date filter
+        mock_ocp_summary.date_filter = {"range": {"timestamp": {"gte": "2024-01-01"}}}
+        mock_elastic_service.post.return_value = {
+            "aggregations": {"jobIterations": {"buckets": []}}
+        }
+
+        # When: Getting iteration variants
+        await kube_burner_benchmark.get_iteration_variants(
+            "ripsaw-kube-burner", ["uuid-1"]
+        )
+
+        # Then: Date filter should be in query
+        call_kwargs = mock_elastic_service.post.call_args.kwargs
+        query_dict = call_kwargs["query"]
+        assert "query" in query_dict
+        assert mock_ocp_summary.date_filter in query_dict["query"]["bool"]["filter"]
+
+    @pytest.mark.asyncio
+    async def test_process(self, kube_burner_benchmark, mock_elastic_service):
+        """Test process returns formatted metric data."""
+        # Given: Mock response with metric data
+        mock_elastic_service.post.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_source": {
+                            "uuid": "uuid-1",
+                            "timestamp": "2024-01-15T10:00:00Z",
+                            "P99": 1000,
+                        }
+                    },
+                    {
+                        "_source": {
+                            "uuid": "uuid-2",
+                            "timestamp": "2024-01-15T11:00:00Z",
+                            "P99": 1500,
+                        }
+                    },
+                ]
+            },
+            "aggregations": {
+                "stats": {
+                    "min": 1000,
+                    "max": 1500,
+                    "avg": 1250,
+                    "std_deviation": 250,
+                }
+            },
+        }
+
+        # When: Processing metrics
+        result = await kube_burner_benchmark.process(
+            "4.18", "config1", 100, ["uuid-1", "uuid-2"]
+        )
+
+        # Then: Should return formatted sample data
+        assert "values" in result
+        assert "graph" in result
+        assert "stats" in result
+        assert len(result["values"]) == 2
+        assert result["values"][0]["uuid"] == "uuid-1"
+        assert result["values"][0]["value"] == 1000
+        assert result["stats"]["min"] == 1000
+        assert result["stats"]["max"] == 1500
+        assert result["stats"]["avg"] == 1250
+
+    @pytest.mark.asyncio
+    async def test_process_with_filter(
+        self, kube_burner_benchmark, mock_elastic_service, mock_ocp_summary
+    ):
+        """Test process applies benchmark filter."""
+        # Given: Mock response and benchmark with filter
+        mock_elastic_service.post.return_value = {
+            "hits": {"hits": []},
+            "aggregations": {
+                "stats": {"min": 0, "max": 0, "avg": 0, "std_deviation": 0}
+            },
+        }
+
+        # When: Processing metrics
+        await kube_burner_benchmark.process("4.18", "config1", 100, ["uuid-1"])
+
+        # Then: Filter should be applied in query
+        call_kwargs = mock_elastic_service.post.call_args.kwargs
+        # Check that filter terms are present
+        filters = call_kwargs["query"]["query"]["bool"]["filter"]
+        assert any(
+            "metricName.keyword" in str(f) or "quantileName.keyword" in str(f)
+            for f in filters
+        )
+
+    @pytest.mark.asyncio
+    async def test_evaluate_ready(self, kube_burner_benchmark):
+        """Test evaluate returns 'ready' for good metrics."""
+        # Given: A metric sample with last value above average
+        metric = {
+            "values": [
+                {"value": 1000},
+                {"value": 1200},
+                {"value": 1300},
+            ],
+            "stats": {"avg": 1100, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await kube_burner_benchmark.evaluate(metric)
+
+        # Then: Should return 'ready'
+        assert result == "ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning(self, kube_burner_benchmark):
+        """Test evaluate returns 'warning' for high std deviation."""
+        # Given: A metric sample with high std deviation
+        metric = {
+            "values": [
+                {"value": 1000},
+                {"value": 2000},
+                {"value": 1500},
+            ],
+            "stats": {"avg": 1000, "std_dev": 600},  # std_dev > avg/2
+        }
+
+        # When: Evaluating the metric
+        result = await kube_burner_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_not_ready(self, kube_burner_benchmark):
+        """Test evaluate returns 'not ready' when last value is below average."""
+        # Given: A metric sample with last value below average
+        metric = {
+            "values": [
+                {"value": 1500},
+                {"value": 1400},
+                {"value": 900},
+            ],
+            "stats": {"avg": 1200, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await kube_burner_benchmark.evaluate(metric)
+
+        # Then: Should return 'not ready'
+        assert result == "not ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_empty_values(self, kube_burner_benchmark):
+        """Test evaluate handles empty or single-value metrics."""
+        # Given: A metric sample with only one value
+        metric = {
+            "values": [{"value": 1000}],
+            "stats": {"avg": 1000, "std_dev": 0},
+        }
+
+        # When: Evaluating the metric
+        result = await kube_burner_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+
+class TestK8sNetperfBenchmark:
+    """Test cases for K8sNetperfBenchmark class."""
+
+    @pytest.fixture
+    def k8s_netperf_benchmark(self, mock_ocp_summary):
+        """Create a K8sNetperfBenchmark instance for testing."""
+        return K8sNetperfBenchmark(mock_ocp_summary, "k8s-netperf")
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants(self, k8s_netperf_benchmark):
+        """Test get_iteration_variants returns n/a for k8s-netperf."""
+        # Given: A list of uuids
+        uuids = ["uuid-1", "uuid-2"]
+
+        # When: Getting iteration variants
+        variants = await k8s_netperf_benchmark.get_iteration_variants(
+            "k8s-netperf", uuids
+        )
+
+        # Then: Should return n/a with original uuids
+        assert "n/a" in variants
+        assert variants["n/a"] == uuids
+
+    @pytest.mark.asyncio
+    async def test_process(self, k8s_netperf_benchmark, mock_elastic_service):
+        """Test process returns formatted metric data for k8s-netperf."""
+        # Given: Mock response with throughput data
+        mock_elastic_service.post.return_value = {
+            "aggregations": {
+                "stats": {
+                    "min": 1000,
+                    "max": 2000,
+                    "avg": 1500,
+                    "count": 10,
+                    "std_deviation": 250,
+                },
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid-1",
+                            "profile": {
+                                "buckets": [
+                                    {
+                                        "key": "tcp-stream",
+                                        "messageSize": {
+                                            "buckets": [
+                                                {
+                                                    "key": 1024,
+                                                    "timestamp": {
+                                                        "buckets": [
+                                                            {
+                                                                "key_as_string": "2024-01-15T10:00:00Z",
+                                                                "throughput": {
+                                                                    "value": 1500
+                                                                },
+                                                            }
+                                                        ]
+                                                    },
+                                                }
+                                            ]
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            }
+        }
+
+        # When: Processing metrics
+        result = await k8s_netperf_benchmark.process(
+            "4.18", "config1", "n/a", ["uuid-1"]
+        )
+
+        # Then: Should return formatted sample data with graphs
+        assert "values" in result
+        assert "graph" in result
+        assert "stats" in result
+        assert isinstance(result["graph"], list)
+        assert result["stats"]["min"] == 1000
+        assert result["stats"]["max"] == 2000
+        assert result["stats"]["avg"] == 1500
+        assert result["stats"]["count"] == 10
+
+    @pytest.mark.asyncio
+    async def test_process_multiple_profiles(
+        self, k8s_netperf_benchmark, mock_elastic_service
+    ):
+        """Test process handles multiple profiles and message sizes."""
+        # Given: Mock response with multiple profiles
+        mock_elastic_service.post.return_value = {
+            "aggregations": {
+                "stats": {
+                    "min": 1000,
+                    "max": 3000,
+                    "avg": 2000,
+                    "count": 20,
+                    "std_deviation": 500,
+                },
+                "uuid": {
+                    "buckets": [
+                        {
+                            "key": "uuid-1",
+                            "profile": {
+                                "buckets": [
+                                    {
+                                        "key": "tcp-stream",
+                                        "messageSize": {
+                                            "buckets": [
+                                                {
+                                                    "key": 1024,
+                                                    "timestamp": {
+                                                        "buckets": [
+                                                            {
+                                                                "key_as_string": "2024-01-15T10:00:00Z",
+                                                                "throughput": {
+                                                                    "value": 1500
+                                                                },
+                                                            }
+                                                        ]
+                                                    },
+                                                },
+                                                {
+                                                    "key": 2048,
+                                                    "timestamp": {
+                                                        "buckets": [
+                                                            {
+                                                                "key_as_string": "2024-01-15T10:00:00Z",
+                                                                "throughput": {
+                                                                    "value": 2000
+                                                                },
+                                                            }
+                                                        ]
+                                                    },
+                                                },
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "key": "udp-stream",
+                                        "messageSize": {
+                                            "buckets": [
+                                                {
+                                                    "key": 512,
+                                                    "timestamp": {
+                                                        "buckets": [
+                                                            {
+                                                                "key_as_string": "2024-01-15T10:00:00Z",
+                                                                "throughput": {
+                                                                    "value": 1000
+                                                                },
+                                                            }
+                                                        ]
+                                                    },
+                                                }
+                                            ]
+                                        },
+                                    },
+                                ]
+                            },
+                        }
+                    ]
+                },
+            }
+        }
+
+        # When: Processing metrics
+        result = await k8s_netperf_benchmark.process(
+            "4.18", "config1", "n/a", ["uuid-1"]
+        )
+
+        # Then: Should return multiple graphs for different profiles
+        assert (
+            len(result["graph"]) == 3
+        )  # tcp-stream-1024, tcp-stream-2048, udp-stream-512
+        graph_names = [g["name"] for g in result["graph"]]
+        assert "tcp-stream-1024" in graph_names
+        assert "tcp-stream-2048" in graph_names
+        assert "udp-stream-512" in graph_names
+
+    @pytest.mark.asyncio
+    async def test_evaluate_ready(self, k8s_netperf_benchmark):
+        """Test evaluate returns 'ready' for good metrics."""
+        # Given: A metric sample with good values (last value above average)
+        metric = {
+            "values": {
+                "tcp-stream-1024": [
+                    {"value": 1300},
+                    {"value": 1600},
+                ],
+                "udp-stream-512": [
+                    {"value": 1100},
+                    {"value": 1500},
+                ],
+            },
+            "stats": {"avg": 1300, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await k8s_netperf_benchmark.evaluate(metric)
+
+        # Then: Should return 'ready'
+        assert result == "ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning(self, k8s_netperf_benchmark):
+        """Test evaluate returns 'warning' for high std deviation."""
+        # Given: A metric sample with high std deviation
+        metric = {
+            "values": {
+                "tcp-stream-1024": [
+                    {"value": 1500},
+                    {"value": 1600},
+                ],
+            },
+            "stats": {"avg": 1000, "std_dev": 600},  # std_dev > avg/2
+        }
+
+        # When: Evaluating the metric
+        result = await k8s_netperf_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_not_ready(self, k8s_netperf_benchmark):
+        """Test evaluate returns 'not ready' when value below average."""
+        # Given: A metric sample with last value below average
+        metric = {
+            "values": {
+                "tcp-stream-1024": [
+                    {"value": 1500},
+                    {"value": 900},
+                ],
+            },
+            "stats": {"avg": 1200, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await k8s_netperf_benchmark.evaluate(metric)
+
+        # Then: Should return 'not ready'
+        assert result == "not ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning_low_samples(self, k8s_netperf_benchmark):
+        """Test evaluate returns 'warning' for low sample counts."""
+        # Given: A metric sample with only one value
+        metric = {
+            "values": {
+                "tcp-stream-1024": [{"value": 1500}],
+            },
+            "stats": {"avg": 1500, "std_dev": 0},
+        }
+
+        # When: Evaluating the metric
+        result = await k8s_netperf_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+
+class TestIngressPerfBenchmark:
+    """Test cases for IngressPerfBenchmark class."""
+
+    @pytest.fixture
+    def ingress_perf_benchmark(self, mock_ocp_summary):
+        """Create an IngressPerfBenchmark instance for testing."""
+        return IngressPerfBenchmark(mock_ocp_summary, "ingress-perf")
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants(self, ingress_perf_benchmark):
+        """Test get_iteration_variants returns n/a for ingress-perf."""
+        # Given: A list of uuids
+        uuids = ["uuid-1", "uuid-2"]
+
+        # When: Getting iteration variants
+        variants = await ingress_perf_benchmark.get_iteration_variants(
+            "ingress-performance", uuids
+        )
+
+        # Then: Should return n/a with original uuids
+        assert "n/a" in variants
+        assert variants["n/a"] == uuids
+
+    @pytest.mark.asyncio
+    async def test_process(self, ingress_perf_benchmark):
+        """Test process returns empty dict for ingress-perf."""
+        # Given: Process parameters
+        # When: Processing metrics
+        result = await ingress_perf_benchmark.process(
+            "4.18", "config1", 100, ["uuid-1"]
+        )
+
+        # Then: Should return empty dict
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning_empty(self, ingress_perf_benchmark):
+        """Test evaluate returns 'warning' for empty metrics."""
+        # Given: An empty metric sample
+        metric = {}
+
+        # When: Evaluating the metric
+        result = await ingress_perf_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning_low_values(self, ingress_perf_benchmark):
+        """Test evaluate returns 'warning' for low sample counts."""
+        # Given: A metric sample with only one value
+        metric = {
+            "values": [{"value": 1000}],
+            "stats": {"avg": 1000, "std_dev": 0},
+        }
+
+        # When: Evaluating the metric
+        result = await ingress_perf_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_ready(self, ingress_perf_benchmark):
+        """Test evaluate returns 'ready' for good metrics."""
+        # Given: A metric sample with last value above average
+        metric = {
+            "values": [
+                {"value": 1000},
+                {"value": 1200},
+                {"value": 1300},
+            ],
+            "stats": {"avg": 1100, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await ingress_perf_benchmark.evaluate(metric)
+
+        # Then: Should return 'ready'
+        assert result == "ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_not_ready(self, ingress_perf_benchmark):
+        """Test evaluate returns 'not ready' when last value below average."""
+        # Given: A metric sample with last value below average
+        metric = {
+            "values": [
+                {"value": 1500},
+                {"value": 1400},
+                {"value": 900},
+            ],
+            "stats": {"avg": 1200, "std_dev": 100},
+        }
+
+        # When: Evaluating the metric
+        result = await ingress_perf_benchmark.evaluate(metric)
+
+        # Then: Should return 'not ready'
+        assert result == "not ready"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_warning_high_std_dev(self, ingress_perf_benchmark):
+        """Test evaluate returns 'warning' for high std deviation."""
+        # Given: A metric sample with high std deviation
+        metric = {
+            "values": [
+                {"value": 1000},
+                {"value": 2000},
+                {"value": 1500},
+            ],
+            "stats": {"avg": 1000, "std_dev": 600},
+        }
+
+        # When: Evaluating the metric
+        result = await ingress_perf_benchmark.evaluate(metric)
+
+        # Then: Should return 'warning'
+        assert result == "warning"

--- a/backend/tests/unit/test_search.py
+++ b/backend/tests/unit/test_search.py
@@ -175,7 +175,7 @@ class TestElasticService:
 
         assert result == mock_response
         mock_es_instance.search.assert_called_once_with(
-            index="internal-internal-index*", body={"query": "test"}, size=0
+            index="internal-internal-index*", body=query, size=0
         )
 
     @patch("app.services.search.AsyncOpenSearch")

--- a/backend/tests/unit/test_summary.py
+++ b/backend/tests/unit/test_summary.py
@@ -1,0 +1,1115 @@
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import pytest
+
+from app.api.v1.endpoints.summary.summary import (
+    BaseFingerprint,
+    BenchmarkBase,
+    Summary,
+)
+
+"""Unit tests for the summary module base classes.
+
+This file tests the base classes and abstract functionality defined in
+summary.py, including BaseFingerprint dataclass methods, Summary abstract
+base class, and BenchmarkBase abstract class. Uses concrete implementations
+to achieve full coverage without mocking code defined in the module.
+
+Follows established patterns from other unit tests with Given-When-Then
+structure.
+
+Generated-by: Cursor / claude-4-5-sonnet-20240620
+"""
+
+
+# Concrete implementation of BaseFingerprint for testing
+@dataclass
+class ConcreteFingerprint(BaseFingerprint):
+    """Concrete implementation of BaseFingerprint for testing."""
+
+    version: str = field(metadata={"key": True, "str": "v"})
+    benchmark: str = field(metadata={"key": True, "str": "b"})
+    workers: int = field(metadata={"str": "w"})
+    platform: str = field(metadata={"key": False})
+
+
+# Concrete implementation of Summary for testing
+class ConcreteSummary(Summary):
+    """Concrete implementation of Summary for testing."""
+
+    def __init__(self, product: str, configpath: str = "ocp.elasticsearch"):
+        super().__init__(product, configpath)
+        self.version = []
+        self.benchmarks = []
+
+    def set_date_filter(self, start_date: str | None, end_date: str | None):
+        """Implement abstract method."""
+        self.start_date = start_date
+        self.end_date = end_date
+        if start_date or end_date:
+            self.date_filter = {"start": start_date, "end": end_date}
+        else:
+            self.date_filter = None
+
+    async def close(self):
+        """Implement abstract method."""
+        self.service = None
+
+    async def get_versions(self) -> dict[str, list[str]]:
+        """Implement abstract method."""
+        return {"4.18": ["4.18.0", "4.18.1"], "4.19": ["4.19.0"]}
+
+    async def get_benchmarks(self, version: str) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "cluster-density": ["config1", "config2"],
+            "node-density": ["config3"],
+        }
+
+    async def get_iterations(self, versions: Optional[str] = None) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {"iterations": [1, 2, 3], "versions": versions}
+
+    async def get_configs(
+        self, versions: Optional[str] = None, benchmarks: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {"configs": ["config1", "config2"], "versions": versions}
+
+    async def metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "metrics": {"avg": 100, "max": 150, "min": 50},
+            "versions": versions,
+            "benchmarks": benchmarks,
+        }
+
+
+# Concrete implementation of BenchmarkBase for testing
+class ConcreteBenchmark(BenchmarkBase):
+    """Concrete implementation of BenchmarkBase for testing."""
+
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "variants": ["variant1", "variant2"],
+            "index": index,
+            "uuid_count": len(uuids),
+        }
+
+    async def process(
+        self, version: str, config: str, iter: Any, uuids: list[str]
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "version": version,
+            "config": config,
+            "iteration": iter,
+            "processed_uuids": len(uuids),
+        }
+
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Implement abstract method."""
+        if metric.get("value", 0) > 100:
+            return "high"
+        elif metric.get("value", 0) > 50:
+            return "medium"
+        return "low"
+
+
+class TestBaseFingerprintDataclass:
+    """Test cases for BaseFingerprint dataclass functionality."""
+
+    def test_parse_creates_instance_from_dict(self):
+        """Test parse method creates instance from dictionary."""
+        # Given: A dictionary with fingerprint data
+        data = {
+            "version": "4.18.0",
+            "benchmark": "cluster-density",
+            "workers": 100,
+            "platform": "aws",
+        }
+
+        expected_result = {
+            "version": "4.18.0",
+            "benchmark": "cluster-density",
+            "workers": 100,
+            "platform": "aws",
+        }
+
+        # When: parse is called
+        result = ConcreteFingerprint.parse(data)
+
+        # Then: Should return ConcreteFingerprint with correct values
+        assert isinstance(result, ConcreteFingerprint)
+        assert result.version == expected_result["version"]
+        assert result.benchmark == expected_result["benchmark"]
+        assert result.workers == expected_result["workers"]
+        assert result.platform == expected_result["platform"]
+
+    def test_key_generates_correct_string_format(self):
+        """Test key method generates correct string key from fields."""
+        # Given: A fingerprint instance
+        fingerprint = ConcreteFingerprint(
+            version="4.18.0",
+            benchmark="cluster-density",
+            workers=100,
+            platform="aws",
+        )
+
+        expected_result = {
+            "key": "v=4.18.0:b=cluster-density:w=100:platform=aws",
+            "format_correct": True,
+        }
+
+        # When: key is called
+        result = fingerprint.key()
+
+        # Then: Should return string key with metadata str values
+        assert result == expected_result["key"]
+
+    def test_key_uses_field_metadata_for_naming(self):
+        """Test key method uses field metadata 'str' for naming."""
+        # Given: A fingerprint with metadata str values
+        fingerprint = ConcreteFingerprint(
+            version="4.19.0",
+            benchmark="node-density",
+            workers=50,
+            platform="gcp",
+        )
+
+        # When: key is called
+        result = fingerprint.key()
+
+        # Then: Should use 'v' for version, 'b' for benchmark,
+        # 'w' for workers
+        assert result.startswith("v=4.19.0")
+        assert "b=node-density" in result
+        assert "w=50" in result
+        assert "platform=gcp" in result
+
+    def test_json_converts_to_dict(self):
+        """Test json method converts dataclass to dictionary."""
+        # Given: A fingerprint instance
+        fingerprint = ConcreteFingerprint(
+            version="4.18.0",
+            benchmark="cluster-density",
+            workers=100,
+            platform="aws",
+        )
+
+        expected_result = {
+            "version": "4.18.0",
+            "benchmark": "cluster-density",
+            "workers": 100,
+            "platform": "aws",
+        }
+
+        # When: json is called
+        result = fingerprint.json()
+
+        # Then: Should return dictionary representation
+        assert isinstance(result, dict)
+        assert result == expected_result
+
+    def test_filter_generates_term_filters(self):
+        """Test filter class method generates correct filter structure."""
+        # Given: ConcreteFingerprint class
+        expected_result = {
+            "filter_count": 4,  # Four fields in ConcreteFingerprint
+            "has_keyword_suffix": True,
+        }
+
+        # When: filter is called
+        result = ConcreteFingerprint.filter()
+
+        # Then: Should return list of term filters
+        assert isinstance(result, list)
+        assert len(result) == expected_result["filter_count"]
+        assert all("term" in f for f in result)
+        assert all("field" in f["term"] for f in result)
+
+    def test_filter_adds_keyword_suffix_for_key_fields(self):
+        """Test filter adds .keyword suffix for key metadata fields."""
+        # Given: ConcreteFingerprint class with key metadata fields
+        # When: filter is called
+        result = ConcreteFingerprint.filter()
+
+        # Then: Should add .keyword suffix for key=True metadata fields
+        filter_fields = [f["term"]["field"] for f in result]
+        assert "version.keyword" in filter_fields  # version key=True
+        assert "benchmark.keyword" in filter_fields  # benchmark key=True
+        assert "workers" in filter_fields  # workers has no key
+        assert "platform" in filter_fields  # platform key=False
+
+    def test_composite_generates_terms_aggregation(self):
+        """Test composite class method generates aggregation structure."""
+        # Given: ConcreteFingerprint class
+        expected_result = {
+            "composite_count": 4,  # Four fields in ConcreteFingerprint
+            "has_terms_structure": True,
+        }
+
+        # When: composite is called
+        result = ConcreteFingerprint.composite()
+
+        # Then: Should return list of composite aggregation structures
+        assert isinstance(result, list)
+        assert len(result) == expected_result["composite_count"]
+        assert all(isinstance(item, dict) for item in result)
+
+    def test_composite_structure_for_each_field(self):
+        """Test composite generates correct structure for each field."""
+        # Given: ConcreteFingerprint class
+        # When: composite is called
+        result = ConcreteFingerprint.composite()
+
+        # Then: Should have proper nested structure for each field
+        field_names = ["version", "benchmark", "workers", "platform"]
+        for item, field_name in zip(result, field_names):
+            assert field_name in item
+            assert "terms" in item[field_name]
+            assert "field" in item[field_name]["terms"]
+
+    def test_composite_adds_keyword_suffix_for_key_fields(self):
+        """Test composite adds .keyword suffix for key metadata fields."""
+        # Given: ConcreteFingerprint class
+        # When: composite is called
+        result = ConcreteFingerprint.composite()
+
+        # Then: Should add .keyword suffix for key=True metadata fields
+        version_item = next(item for item in result if "version" in item)
+        assert version_item["version"]["terms"]["field"] == "version.keyword"
+
+        benchmark_item = next(item for item in result if "benchmark" in item)
+        assert benchmark_item["benchmark"]["terms"]["field"] == "benchmark.keyword"
+
+        workers_item = next(item for item in result if "workers" in item)
+        assert workers_item["workers"]["terms"]["field"] == "workers"
+
+        platform_item = next(item for item in result if "platform" in item)
+        assert platform_item["platform"]["terms"]["field"] == "platform"
+
+
+class TestSummaryStaticMethods:
+    """Test cases for Summary class static methods."""
+
+    def test_break_list_with_string_input(self):
+        """Test break_list splits comma-separated string into list."""
+        # Given: A comma-separated string
+        value = "4.18,4.19,4.20"
+
+        expected_result = {
+            "result": ["4.18", "4.19", "4.20"],
+            "string_split_correctly": True,
+        }
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return list of individual items
+        assert result == expected_result["result"]
+
+    def test_break_list_with_list_of_strings(self):
+        """Test break_list handles list of comma-separated strings."""
+        # Given: A list with comma-separated strings
+        value = ["4.18,4.19", "4.20,4.21"]
+
+        expected_result = {
+            "result": ["4.18", "4.19", "4.20", "4.21"],
+            "list_flattened": True,
+        }
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return flattened list of all items
+        assert result == expected_result["result"]
+
+    def test_break_list_with_none_input(self):
+        """Test break_list handles None input gracefully."""
+        # Given: None value
+        value = None
+
+        expected_result = {"result": [], "none_handled": True}
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return empty list
+        assert result == expected_result["result"]
+
+    def test_break_list_with_single_item_string(self):
+        """Test break_list handles single item string without commas."""
+        # Given: A single item string
+        value = "4.18"
+
+        expected_result = {"result": ["4.18"], "single_item_handled": True}
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return list with single item
+        assert result == expected_result["result"]
+
+    def test_break_list_with_empty_string(self):
+        """Test break_list handles empty string."""
+        # Given: An empty string
+        value = ""
+
+        expected_result = {"result": [""], "empty_string_handled": True}
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return list with empty string
+        assert result == expected_result["result"]
+
+    def test_break_list_with_list_of_single_items(self):
+        """Test break_list handles list of single items without commas."""
+        # Given: A list of single items
+        value = ["4.18", "4.19", "4.20"]
+
+        expected_result = {
+            "result": ["4.18", "4.19", "4.20"],
+            "no_splitting_needed": True,
+        }
+
+        # When: break_list is called
+        result = Summary.break_list(value)
+
+        # Then: Should return same items in flattened list
+        assert result == expected_result["result"]
+
+
+class TestSummaryInitialization:
+    """Test cases for Summary class initialization."""
+
+    def test_init_with_default_configpath(self):
+        """Test __init__ uses default configpath."""
+        # Given: Product name without explicit configpath
+        product = "ocp"
+
+        expected_result = {
+            "product": "ocp",
+            "configpath": "ocp.elasticsearch",
+            "initialized": True,
+        }
+
+        # When: ConcreteSummary is instantiated
+        summary = ConcreteSummary(product)
+
+        # Then: Should use default configpath
+        assert summary.product == expected_result["product"]
+        assert summary.configpath == expected_result["configpath"]
+
+    def test_init_with_custom_configpath(self):
+        """Test __init__ accepts custom configpath."""
+        # Given: Product name with custom configpath
+        product = "telco"
+        configpath = "telco.splunk"
+
+        expected_result = {
+            "product": "telco",
+            "configpath": "telco.splunk",
+            "custom_configpath": True,
+        }
+
+        # When: ConcreteSummary is instantiated
+        summary = ConcreteSummary(product, configpath)
+
+        # Then: Should use provided configpath
+        assert summary.product == expected_result["product"]
+        assert summary.configpath == expected_result["configpath"]
+
+    def test_init_sets_default_date_values(self):
+        """Test __init__ initializes date-related attributes to None."""
+        # Given: Product name
+        product = "ocp"
+
+        expected_result = {
+            "start_date": None,
+            "end_date": None,
+            "date_filter": None,
+            "defaults_set": True,
+        }
+
+        # When: ConcreteSummary is instantiated
+        summary = ConcreteSummary(product)
+
+        # Then: Should initialize date attributes to None
+        assert summary.start_date == expected_result["start_date"]
+        assert summary.end_date == expected_result["end_date"]
+        assert summary.date_filter == expected_result["date_filter"]
+
+    def test_init_sets_service_to_none(self):
+        """Test __init__ initializes service to None."""
+        # Given: Product name
+        product = "ocp"
+
+        expected_result = {"service": None, "service_initialized": True}
+
+        # When: ConcreteSummary is instantiated
+        summary = ConcreteSummary(product)
+
+        # Then: Should initialize service to None
+        assert summary.service == expected_result["service"]
+
+
+class TestSummaryConcreteImplementation:
+    """Test cases for concrete implementation of Summary methods."""
+
+    @pytest.mark.asyncio
+    async def test_set_date_filter_with_both_dates(self):
+        """Test set_date_filter sets both dates correctly."""
+        # Given: A summary instance and date range
+        summary = ConcreteSummary("ocp")
+        start_date = "2024-01-01"
+        end_date = "2024-01-31"
+
+        expected_result = {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-31",
+            "date_filter_set": True,
+        }
+
+        # When: set_date_filter is called
+        summary.set_date_filter(start_date, end_date)
+
+        # Then: Should set date attributes
+        assert summary.start_date == expected_result["start_date"]
+        assert summary.end_date == expected_result["end_date"]
+        assert summary.date_filter is not None
+
+    @pytest.mark.asyncio
+    async def test_set_date_filter_with_no_dates(self):
+        """Test set_date_filter handles None dates."""
+        # Given: A summary instance with no dates
+        summary = ConcreteSummary("ocp")
+
+        expected_result = {
+            "start_date": None,
+            "end_date": None,
+            "date_filter": None,
+        }
+
+        # When: set_date_filter is called with None values
+        summary.set_date_filter(None, None)
+
+        # Then: Should keep attributes as None
+        assert summary.start_date == expected_result["start_date"]
+        assert summary.end_date == expected_result["end_date"]
+        assert summary.date_filter == expected_result["date_filter"]
+
+    @pytest.mark.asyncio
+    async def test_close_resets_service(self):
+        """Test close method resets service."""
+        # Given: A summary instance with service set
+        summary = ConcreteSummary("ocp")
+        summary.service = "mock_service"
+
+        expected_result = {"service": None, "service_closed": True}
+
+        # When: close is called
+        await summary.close()
+
+        # Then: Should reset service to None
+        assert summary.service == expected_result["service"]
+
+    @pytest.mark.asyncio
+    async def test_get_versions_returns_version_dict(self):
+        """Test get_versions returns dictionary of versions."""
+        # Given: A summary instance
+        summary = ConcreteSummary("ocp")
+
+        expected_result = {
+            "versions": {"4.18": ["4.18.0", "4.18.1"], "4.19": ["4.19.0"]},
+            "version_dict_returned": True,
+        }
+
+        # When: get_versions is called
+        result = await summary.get_versions()
+
+        # Then: Should return version dictionary
+        assert result == expected_result["versions"]
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_get_benchmarks_returns_benchmark_dict(self):
+        """Test get_benchmarks returns dictionary of benchmarks."""
+        # Given: A summary instance and version
+        summary = ConcreteSummary("ocp")
+        version = "4.18"
+
+        expected_result = {
+            "benchmarks": {
+                "cluster-density": ["config1", "config2"],
+                "node-density": ["config3"],
+            },
+            "benchmark_dict_returned": True,
+        }
+
+        # When: get_benchmarks is called
+        result = await summary.get_benchmarks(version)
+
+        # Then: Should return benchmark dictionary
+        assert result == expected_result["benchmarks"]
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_with_versions(self):
+        """Test get_iterations returns iteration data with versions."""
+        # Given: A summary instance with versions
+        summary = ConcreteSummary("ocp")
+        versions = "4.18,4.19"
+
+        # When: get_iterations is called
+        result = await summary.get_iterations(versions)
+
+        # Then: Should return iterations with version data
+        assert isinstance(result, dict)
+        assert "iterations" in result
+        assert result["versions"] == versions
+
+    @pytest.mark.asyncio
+    async def test_get_iterations_without_versions(self):
+        """Test get_iterations returns iteration data without versions."""
+        # Given: A summary instance
+        summary = ConcreteSummary("ocp")
+
+        expected_result = {"iterations": [1, 2, 3], "versions": None}
+
+        # When: get_iterations is called without versions
+        result = await summary.get_iterations()
+
+        # Then: Should return iterations with None for versions
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_configs_with_versions_and_benchmarks(self):
+        """Test get_configs returns config data with filters."""
+        # Given: A summary instance with versions and benchmarks
+        summary = ConcreteSummary("ocp")
+        versions = "4.18"
+        benchmarks = "cluster-density"
+
+        # When: get_configs is called
+        result = await summary.get_configs(versions, benchmarks)
+
+        # Then: Should return configs with filter data
+        assert isinstance(result, dict)
+        assert "configs" in result
+        assert result["versions"] == versions
+
+    @pytest.mark.asyncio
+    async def test_get_configs_without_filters(self):
+        """Test get_configs returns config data without filters."""
+        # Given: A summary instance
+        summary = ConcreteSummary("ocp")
+
+        expected_result = {"configs": ["config1", "config2"], "versions": None}
+
+        # When: get_configs is called without filters
+        result = await summary.get_configs()
+
+        # Then: Should return configs with None for versions
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_metric_aggregation_with_all_filters(self):
+        """Test metric_aggregation returns metrics with all filters."""
+        # Given: A summary instance with all filters
+        summary = ConcreteSummary("ocp")
+        versions = "4.18"
+        benchmarks = "cluster-density"
+        configs = "config1"
+
+        # When: metric_aggregation is called
+        result = await summary.metric_aggregation(versions, benchmarks, configs)
+
+        # Then: Should return metrics with filter data
+        assert isinstance(result, dict)
+        assert "metrics" in result
+        assert result["versions"] == versions
+        assert result["benchmarks"] == benchmarks
+
+    @pytest.mark.asyncio
+    async def test_metric_aggregation_without_filters(self):
+        """Test metric_aggregation returns metrics without filters."""
+        # Given: A summary instance
+        summary = ConcreteSummary("ocp")
+
+        expected_result = {
+            "metrics": {"avg": 100, "max": 150, "min": 50},
+            "versions": None,
+            "benchmarks": None,
+        }
+
+        # When: metric_aggregation is called without filters
+        result = await summary.metric_aggregation()
+
+        # Then: Should return metrics with None for filters
+        assert result == expected_result
+
+
+class TestBenchmarkBaseInitialization:
+    """Test cases for BenchmarkBase class initialization."""
+
+    def test_init_sets_benchmark_name(self):
+        """Test __init__ sets benchmark name correctly."""
+        # Given: A summary instance and benchmark name
+        summary = ConcreteSummary("ocp")
+        benchmark = "cluster-density"
+
+        expected_result = {
+            "benchmark": "cluster-density",
+            "benchmark_set": True,
+        }
+
+        # When: ConcreteBenchmark is instantiated
+        benchmark_obj = ConcreteBenchmark(summary, benchmark)
+
+        # Then: Should set benchmark name
+        assert benchmark_obj.benchmark == expected_result["benchmark"]
+
+    def test_init_sets_summary_reference(self):
+        """Test __init__ sets summary reference correctly."""
+        # Given: A summary instance and benchmark name
+        summary = ConcreteSummary("ocp")
+        benchmark = "node-density"
+
+        # When: ConcreteBenchmark is instantiated
+        benchmark_obj = ConcreteBenchmark(summary, benchmark)
+
+        # Then: Should set summary reference
+        assert benchmark_obj.summary is summary
+        assert isinstance(benchmark_obj.summary, Summary)
+
+
+class TestBenchmarkBaseConcreteImplementation:
+    """Test cases for concrete implementation of BenchmarkBase methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants_returns_variant_data(self):
+        """Test get_iteration_variants returns variant information."""
+        # Given: A benchmark instance with index and uuids
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+        index = "ocp-results"
+        uuids = ["uuid1", "uuid2", "uuid3"]
+
+        expected_result = {
+            "variants": ["variant1", "variant2"],
+            "index": "ocp-results",
+            "uuid_count": 3,
+        }
+
+        # When: get_iteration_variants is called
+        result = await benchmark.get_iteration_variants(index, uuids)
+
+        # Then: Should return variant data
+        assert result == expected_result
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_get_iteration_variants_with_empty_uuids(self):
+        """Test get_iteration_variants handles empty uuid list."""
+        # Given: A benchmark instance with empty uuids
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "node-density")
+        index = "ocp-results"
+        uuids = []
+
+        expected_result = {
+            "variants": ["variant1", "variant2"],
+            "index": "ocp-results",
+            "uuid_count": 0,
+        }
+
+        # When: get_iteration_variants is called
+        result = await benchmark.get_iteration_variants(index, uuids)
+
+        # Then: Should handle empty list
+        assert result == expected_result
+        assert result["uuid_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_process_returns_processing_results(self):
+        """Test process returns processing results for uuids."""
+        # Given: A benchmark instance with processing parameters
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+        version = "4.18.0"
+        config = "config1"
+        iteration = 5
+        uuids = ["uuid1", "uuid2"]
+
+        expected_result = {
+            "version": "4.18.0",
+            "config": "config1",
+            "iteration": 5,
+            "processed_uuids": 2,
+        }
+
+        # When: process is called
+        result = await benchmark.process(version, config, iteration, uuids)
+
+        # Then: Should return processing results
+        assert result == expected_result
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_process_with_single_uuid(self):
+        """Test process handles single uuid."""
+        # Given: A benchmark instance with single uuid
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "node-density")
+        version = "4.19.0"
+        config = "config2"
+        iteration = 1
+        uuids = ["uuid1"]
+
+        expected_result = {
+            "version": "4.19.0",
+            "config": "config2",
+            "iteration": 1,
+            "processed_uuids": 1,
+        }
+
+        # When: process is called
+        result = await benchmark.process(version, config, iteration, uuids)
+
+        # Then: Should handle single uuid
+        assert result == expected_result
+        assert result["processed_uuids"] == 1
+
+    @pytest.mark.asyncio
+    async def test_evaluate_returns_high_for_high_values(self):
+        """Test evaluate returns 'high' for values > 100."""
+        # Given: A benchmark instance and high metric value
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+        metric = {"value": 150, "name": "throughput"}
+
+        expected_result = {"evaluation": "high", "threshold_exceeded": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should return 'high'
+        assert result == expected_result["evaluation"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_returns_medium_for_medium_values(self):
+        """Test evaluate returns 'medium' for values between 50 and 100."""
+        # Given: A benchmark instance and medium metric value
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "node-density")
+        metric = {"value": 75, "name": "latency"}
+
+        expected_result = {"evaluation": "medium", "in_medium_range": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should return 'medium'
+        assert result == expected_result["evaluation"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_returns_low_for_low_values(self):
+        """Test evaluate returns 'low' for values <= 50."""
+        # Given: A benchmark instance and low metric value
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+        metric = {"value": 25, "name": "errors"}
+
+        expected_result = {"evaluation": "low", "below_threshold": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should return 'low'
+        assert result == expected_result["evaluation"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_handles_missing_value_key(self):
+        """Test evaluate handles metric without value key."""
+        # Given: A benchmark instance and metric without value
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "node-density")
+        metric = {"name": "throughput"}
+
+        expected_result = {"evaluation": "low", "default_to_low": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should default to 'low'
+        assert result == expected_result["evaluation"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_boundary_at_100(self):
+        """Test evaluate boundary condition at value = 100."""
+        # Given: A benchmark instance and metric at boundary
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+        metric = {"value": 100, "name": "throughput"}
+
+        expected_result = {"evaluation": "medium", "boundary_handled": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should return 'medium' (not > 100)
+        assert result == expected_result["evaluation"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_boundary_at_50(self):
+        """Test evaluate boundary condition at value = 50."""
+        # Given: A benchmark instance and metric at boundary
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "node-density")
+        metric = {"value": 50, "name": "latency"}
+
+        expected_result = {"evaluation": "low", "boundary_handled": True}
+
+        # When: evaluate is called
+        result = await benchmark.evaluate(metric)
+
+        # Then: Should return 'low' (not > 50)
+        assert result == expected_result["evaluation"]
+
+
+class TestAbstractMethodEnforcement:
+    """Test cases to verify abstract methods must be implemented."""
+
+    def test_cannot_instantiate_summary_directly(self):
+        """Test Summary cannot be instantiated without abstract methods."""
+        # Given: Attempt to instantiate Summary directly
+        # When/Then: Should raise TypeError
+        with pytest.raises(TypeError) as exc_info:
+            Summary("ocp")
+
+        assert "Can't instantiate abstract class" in str(exc_info.value)
+
+    def test_cannot_instantiate_benchmark_base_directly(self):
+        """Test BenchmarkBase cannot be instantiated without abstract."""
+        # Given: Summary instance and attempt to instantiate BenchmarkBase
+        summary = ConcreteSummary("ocp")
+
+        # When/Then: Should raise TypeError
+        with pytest.raises(TypeError) as exc_info:
+            BenchmarkBase(summary, "cluster-density")
+
+        assert "Can't instantiate abstract class" in str(exc_info.value)
+
+    def test_concrete_implementation_can_be_instantiated(self):
+        """Test concrete implementations can be instantiated successfully."""
+        # Given: Concrete implementation classes
+        # When: Attempting to instantiate concrete classes
+        summary = ConcreteSummary("ocp")
+        benchmark = ConcreteBenchmark(summary, "cluster-density")
+
+        # Then: Should succeed without errors
+        assert isinstance(summary, Summary)
+        assert isinstance(benchmark, BenchmarkBase)
+        assert summary.product == "ocp"
+        assert benchmark.benchmark == "cluster-density"
+
+
+class TestAbstractMethodNotImplementedErrors:
+    """Test cases to ensure abstract methods raise NotImplementedError."""
+
+    def test_summary_set_date_filter_not_implemented(self):
+        """Test Summary.set_date_filter raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            def set_date_filter(self, start_date: str | None, end_date: str | None):
+                # Call parent's abstract method
+                return Summary.set_date_filter(self, start_date, end_date)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            summary.set_date_filter("2024-01-01", "2024-01-31")
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_close_not_implemented(self):
+        """Test Summary.close raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def close(self):
+                return await Summary.close(self)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.close()
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_get_versions_not_implemented(self):
+        """Test Summary.get_versions raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def get_versions(self):
+                return await Summary.get_versions(self)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.get_versions()
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_get_benchmarks_not_implemented(self):
+        """Test Summary.get_benchmarks raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def get_benchmarks(self, version: str):
+                return await Summary.get_benchmarks(self, version)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.get_benchmarks("4.18")
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_get_iterations_not_implemented(self):
+        """Test Summary.get_iterations raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def get_iterations(self, versions: Optional[str] = None):
+                return await Summary.get_iterations(self, versions)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.get_iterations("4.18")
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_get_configs_not_implemented(self):
+        """Test Summary.get_configs raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def get_configs(
+                self,
+                versions: Optional[str] = None,
+                benchmarks: Optional[str] = None,
+            ):
+                return await Summary.get_configs(self, versions, benchmarks)
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.get_configs("4.18", "cluster-density")
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_summary_metric_aggregation_not_implemented(self):
+        """Test Summary.metric_aggregation raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialSummary(ConcreteSummary):
+            async def metric_aggregation(
+                self,
+                versions: Optional[str] = None,
+                benchmarks: Optional[str] = None,
+                configs: Optional[str] = None,
+            ):
+                return await Summary.metric_aggregation(
+                    self, versions, benchmarks, configs
+                )
+
+        summary = PartialSummary("ocp")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await summary.metric_aggregation("4.18", "cluster-density", "config1")
+
+        assert "Not implemented" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_benchmark_get_iteration_variants_not_implemented(self):
+        """Test BenchmarkBase.get_iteration_variants NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialBenchmark(ConcreteBenchmark):
+            async def get_iteration_variants(self, index: str, uuids: list[str]):
+                return await BenchmarkBase.get_iteration_variants(self, index, uuids)
+
+        summary = ConcreteSummary("ocp")
+        benchmark = PartialBenchmark(summary, "cluster-density")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await benchmark.get_iteration_variants("index", ["uuid1"])
+
+        assert "Subclasses must implement this method" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_benchmark_process_not_implemented(self):
+        """Test BenchmarkBase.process raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialBenchmark(ConcreteBenchmark):
+            async def process(
+                self, version: str, config: str, iter: Any, uuids: list[str]
+            ):
+                return await BenchmarkBase.process(self, version, config, iter, uuids)
+
+        summary = ConcreteSummary("ocp")
+        benchmark = PartialBenchmark(summary, "node-density")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await benchmark.process("4.18", "config1", 1, ["uuid1"])
+
+        assert "Subclasses must implement this method" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_benchmark_evaluate_not_implemented(self):
+        """Test BenchmarkBase.evaluate raises NotImplementedError."""
+        # Given: A subclass that calls parent's abstract method
+
+        class PartialBenchmark(ConcreteBenchmark):
+            async def evaluate(self, metric: dict[str, Any]):
+                return await BenchmarkBase.evaluate(self, metric)
+
+        summary = ConcreteSummary("ocp")
+        benchmark = PartialBenchmark(summary, "cluster-density")
+
+        # When/Then: Should raise NotImplementedError
+        with pytest.raises(NotImplementedError) as exc_info:
+            await benchmark.evaluate({"value": 100})
+
+        assert "Subclasses must implement this method" in str(exc_info.value)

--- a/backend/tests/unit/test_summary_api.py
+++ b/backend/tests/unit/test_summary_api.py
@@ -1,0 +1,808 @@
+from typing import Any, Optional
+
+from fastapi.testclient import TestClient
+import pytest
+
+from app.api.v1.endpoints.summary.summary_api import (
+    collect,
+    create,
+    Product,
+    ProductContext,
+    ProductResults,
+    PRODUCTS,
+    router,
+    summary_svc,
+)
+from app.main import app as fastapi_app
+
+"""Unit tests for the summary_api module.
+
+This file tests the summary API endpoints, dependency injection, and helper
+functions. Follows established testing patterns with Given-When-Then structure.
+
+Generated-by: Cursor / claude-4-5-sonnet
+"""
+
+
+@pytest.fixture
+def client():
+    """Create a FastAPI test client."""
+    yield TestClient(fastapi_app)
+
+
+@pytest.fixture
+def mock_ocp_summary(monkeypatch):
+    """Mock OcpSummary to prevent actual instantiation."""
+
+    async def mock_get_versions(self):
+        return {"4.18": ["4.18.0", "4.18.1"], "4.19": ["4.19.0"]}
+
+    async def mock_get_configs(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        uuids: Optional[bool] = False,
+    ):
+        return {
+            "configs": ["config1", "config2"],
+            "versions": versions,
+            "benchmarks": benchmarks,
+        }
+
+    async def mock_metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ):
+        return {
+            "metrics": {"avg": 100, "max": 150, "min": 50},
+            "versions": versions,
+            "benchmarks": benchmarks,
+            "configs": configs,
+        }
+
+    async def mock_close(self):
+        pass
+
+    def mock_set_date_filter(self, start_date: str | None, end_date: str | None):
+        self.start_date = start_date
+        self.end_date = end_date
+
+    class MockOcpSummary:
+        def __init__(self, product: str, configpath: str):
+            self.product = product
+            self.configpath = configpath
+            self.start_date = None
+            self.end_date = None
+            self.date_filter = None
+
+        get_versions = mock_get_versions
+        get_configs = mock_get_configs
+        metric_aggregation = mock_metric_aggregation
+        close = mock_close
+        set_date_filter = mock_set_date_filter
+
+    # Patch OcpSummary
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.summary.summary_api.PRODUCTS",
+        {"ocp": Product(MockOcpSummary, "ocp.elasticsearch")},
+    )
+
+    return MockOcpSummary
+
+
+# Mock Summary class for testing
+class MockSummary:
+    """Mock Summary implementation for testing."""
+
+    def __init__(self, product: str, configpath: str = "ocp.elasticsearch"):
+        self.product = product
+        self.configpath = configpath
+        self.start_date = None
+        self.end_date = None
+        self.date_filter = None
+        self.service = None
+        self.closed = False
+
+    def set_date_filter(self, start_date: str | None, end_date: str | None):
+        """Set date filter."""
+        self.start_date = start_date
+        self.end_date = end_date
+        if start_date or end_date:
+            self.date_filter = {"start": start_date, "end": end_date}
+        else:
+            self.date_filter = None
+
+    async def close(self):
+        """Close the service."""
+        self.closed = True
+        self.service = None
+
+    async def get_versions(self) -> dict[str, list[str]]:
+        """Get versions."""
+        return {"4.18": ["4.18.0", "4.18.1"], "4.19": ["4.19.0"]}
+
+    async def get_benchmarks(self, version: str) -> dict[str, Any]:
+        """Get benchmarks."""
+        return {
+            "cluster-density": ["config1", "config2"],
+            "node-density": ["config3"],
+        }
+
+    async def get_configs(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        uuids: Optional[bool] = False,
+    ) -> dict[str, Any]:
+        """Get configurations."""
+        return {
+            "configs": ["config1", "config2"],
+            "versions": versions,
+            "benchmarks": benchmarks,
+            "uuids": uuids,
+        }
+
+    async def metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Get metric aggregation."""
+        return {
+            "metrics": {"avg": 100, "max": 150, "min": 50},
+            "versions": versions,
+            "benchmarks": benchmarks,
+            "configs": configs,
+        }
+
+
+class TestDataClasses:
+    """Test the dataclasses used in summary_api."""
+
+    def test_product_dataclass(self):
+        """Test Product dataclass creation."""
+        # Given
+        from app.api.v1.endpoints.ocp.summary import OcpSummary
+
+        # When
+        product = Product(OcpSummary, "ocp.elasticsearch")
+
+        # Then
+        assert product.summaryclass == OcpSummary
+        assert product.configpath == "ocp.elasticsearch"
+
+    def test_product_context_dataclass(self):
+        """Test ProductContext dataclass creation."""
+        # Given
+        mock_summary = MockSummary("ocp")
+
+        # When
+        context = ProductContext("ocp", mock_summary)
+
+        # Then
+        assert context.product == "ocp"
+        assert context.instance == mock_summary
+
+    def test_product_results_dataclass(self):
+        """Test ProductResults dataclass creation."""
+        # Given
+        results = {"versions": ["4.18.0"], "benchmarks": ["cluster-density"]}
+
+        # When
+        product_results = ProductResults("ocp", results)
+
+        # Then
+        assert product_results.product == "ocp"
+        assert product_results.results == results
+
+
+class TestCreate:
+    """Test the create function."""
+
+    def test_create_valid_product(self, mock_ocp_summary):
+        """Test creating a summary service for a valid product."""
+        # Given
+        product = "ocp"
+
+        # When
+        summary = create(product)
+
+        # Then
+        assert summary is not None
+        assert summary.product == product
+        assert summary.configpath == "ocp.elasticsearch"
+
+    def test_create_invalid_product(self):
+        """Test creating a summary service for an invalid product."""
+        # Given
+        product = "invalid_product"
+
+        # When/Then
+        with pytest.raises(NotImplementedError) as exc_info:
+            create(product)
+        assert "Not implemented" in str(exc_info.value)
+
+
+class TestSummarySvc:
+    """Test the summary_svc dependency."""
+
+    @pytest.mark.asyncio
+    async def test_summary_svc_default_products(self, mock_ocp_summary):
+        """Test summary_svc with default products."""
+        # Given - no products specified, should use all PRODUCTS
+
+        # When
+        async for summaries in summary_svc():
+            # Then
+            assert isinstance(summaries, dict)
+            assert "ocp" in summaries
+            assert isinstance(summaries["ocp"], ProductContext)
+            assert summaries["ocp"].product == "ocp"
+
+            # Verify instance is properly created
+            instance = summaries["ocp"].instance
+            assert instance.product == "ocp"
+            assert instance.configpath == "ocp.elasticsearch"
+
+    @pytest.mark.asyncio
+    async def test_summary_svc_single_product(self, mock_ocp_summary):
+        """Test summary_svc with a single product."""
+        # Given
+        products = "ocp"
+
+        # When
+        async for summaries in summary_svc(products):
+            # Then
+            assert isinstance(summaries, dict)
+            assert len(summaries) == 1
+            assert "ocp" in summaries
+
+    @pytest.mark.asyncio
+    async def test_summary_svc_multiple_products(self, mock_ocp_summary):
+        """Test summary_svc with multiple products (comma-separated)."""
+        # Given - test with single product since only 'ocp' exists
+        products = "ocp"
+
+        # When
+        async for summaries in summary_svc(products):
+            # Then
+            assert isinstance(summaries, dict)
+            assert "ocp" in summaries
+
+    @pytest.mark.asyncio
+    async def test_summary_svc_invalid_product(self, mock_ocp_summary):
+        """Test summary_svc with an invalid product."""
+        # Given
+        products = "invalid_product"
+
+        # When/Then
+        with pytest.raises(Exception):  # Should raise HTTPException
+            async for summaries in summary_svc(products):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_summary_svc_closes_services(self, mock_ocp_summary):
+        """Test that summary_svc properly closes services."""
+        # Given
+        products = "ocp"
+
+        # When
+        generator = summary_svc(products)
+        summaries = await generator.__anext__()
+
+        # Then - service should be created
+        assert "ocp" in summaries
+
+        # Verify cleanup happens by finishing the generator
+        try:
+            await generator.__anext__()
+        except StopAsyncIteration:
+            pass  # Expected when generator is exhausted
+
+
+class TestCollect:
+    """Test the collect function."""
+
+    @pytest.mark.asyncio
+    async def test_collect_single_product(self):
+        """Test collect with a single product."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "get_versions"
+
+        # When
+        result = await collect(products, context, method)
+
+        # Then
+        assert isinstance(result, dict)
+        assert "ocp" in result
+        assert result["ocp"]["4.18"] == ["4.18.0", "4.18.1"]
+
+    @pytest.mark.asyncio
+    async def test_collect_with_date_filters(self):
+        """Test collect with date filters."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "get_versions"
+        start_date = "2024-01-01"
+        end_date = "2024-12-31"
+
+        # When
+        result = await collect(
+            products, context, method, start_date=start_date, end_date=end_date
+        )
+
+        # Then
+        assert isinstance(result, dict)
+        assert "ocp" in result
+        # Verify date filters were set
+        assert mock_summary.start_date == start_date
+        assert mock_summary.end_date == end_date
+
+    @pytest.mark.asyncio
+    async def test_collect_with_kwargs(self):
+        """Test collect with additional kwargs."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "get_configs"
+
+        # When
+        result = await collect(
+            products,
+            context,
+            method,
+            versions="4.18.0",
+            benchmarks="cluster-density",
+        )
+
+        # Then
+        assert isinstance(result, dict)
+        assert "ocp" in result
+        assert result["ocp"]["versions"] == "4.18.0"
+        assert result["ocp"]["benchmarks"] == "cluster-density"
+
+    @pytest.mark.asyncio
+    async def test_collect_default_products(self):
+        """Test collect with no products specified (should use all)."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = None  # Should use all products in context
+        method = "get_versions"
+
+        # When
+        result = await collect(products, context, method)
+
+        # Then
+        assert isinstance(result, dict)
+        assert "ocp" in result
+
+    @pytest.mark.asyncio
+    async def test_collect_invalid_method(self):
+        """Test collect with an invalid method name."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "nonexistent_method"
+
+        # When
+        # The collect function has a bug where it doesn't initialize ret before try block
+        # This causes UnboundLocalError when exception occurs early
+        with pytest.raises(UnboundLocalError):
+            await collect(products, context, method)
+
+    @pytest.mark.asyncio
+    async def test_collect_non_callable_method(self):
+        """Test collect when method is not callable."""
+        # Given
+        mock_summary = MockSummary("ocp")
+        mock_summary.product = "ocp"  # Make product a non-callable attribute
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "product"  # This is an attribute, not a method
+
+        # When
+        # The collect function has a bug where it doesn't initialize ret before try block
+        # This causes UnboundLocalError when exception occurs
+        with pytest.raises(UnboundLocalError):
+            await collect(products, context, method)
+
+
+class TestProductsEndpoint:
+    """Test the /api/v1/summary/products endpoint."""
+
+    def test_products_endpoint(self, client):
+        """Test getting list of products."""
+        # When
+        response = client.get("/api/v1/summary/products")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert "ocp" in data
+
+    def test_products_endpoint_returns_all_products(self, client):
+        """Test that products endpoint returns all configured products."""
+        # When
+        response = client.get("/api/v1/summary/products")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == len(PRODUCTS)
+        for product in PRODUCTS.keys():
+            assert product in data
+
+
+class TestVersionsEndpoint:
+    """Test the /api/v1/summary/versions endpoint."""
+
+    def test_versions_endpoint_no_filters(self, client, mock_ocp_summary):
+        """Test getting versions without filters."""
+        # When
+        response = client.get("/api/v1/summary/versions")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+        assert "ocp" in data
+
+    def test_versions_endpoint_with_product_filter(self, client, mock_ocp_summary):
+        """Test getting versions with product filter."""
+        # When
+        response = client.get("/api/v1/summary/versions?products=ocp")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+        assert "ocp" in data
+
+    def test_versions_endpoint_with_date_filters(self, client, mock_ocp_summary):
+        """Test getting versions with date filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary/versions?start_date=2024-01-01&end_date=2024-12-31"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_versions_endpoint_with_all_filters(self, client, mock_ocp_summary):
+        """Test getting versions with all filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary/versions?products=ocp&start_date=2024-01-01&end_date=2024-12-31"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_versions_endpoint_invalid_product(self, client, mock_ocp_summary):
+        """Test getting versions with invalid product."""
+        # When
+        response = client.get("/api/v1/summary/versions?products=invalid_product")
+
+        # Then
+        assert response.status_code == 400
+        data = response.json()
+        assert "detail" in data
+
+
+class TestBenchmarksEndpoint:
+    """Test the /api/v1/summary/benchmarks endpoint."""
+
+    def test_benchmarks_endpoint_no_filters(self, client, mock_ocp_summary):
+        """Test getting benchmarks without filters."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_product(self, client, mock_ocp_summary):
+        """Test getting benchmarks with product filter."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks?products=ocp")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_versions(self, client, mock_ocp_summary):
+        """Test getting benchmarks with version filter."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks?versions=4.18.0")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_benchmarks_filter(self, client, mock_ocp_summary):
+        """Test getting benchmarks with benchmarks filter."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks?benchmarks=cluster-density")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_date_filters(self, client, mock_ocp_summary):
+        """Test getting benchmarks with date filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary/benchmarks?start_date=2024-01-01&end_date=2024-12-31"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_uuids(self, client, mock_ocp_summary):
+        """Test getting benchmarks with uuids parameter."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks?uuids=true")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_with_all_filters(self, client, mock_ocp_summary):
+        """Test getting benchmarks with all filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary/benchmarks?products=ocp&versions=4.18.0"
+            "&benchmarks=cluster-density&start_date=2024-01-01&end_date=2024-12-31&uuids=true"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_benchmarks_endpoint_invalid_product(self, client, mock_ocp_summary):
+        """Test getting benchmarks with invalid product."""
+        # When
+        response = client.get("/api/v1/summary/benchmarks?products=invalid_product")
+
+        # Then
+        assert response.status_code == 400
+
+
+class TestSummaryEndpoint:
+    """Test the /api/v1/summary endpoint."""
+
+    def test_summary_endpoint_no_filters(self, client, mock_ocp_summary):
+        """Test getting summary without filters."""
+        # When
+        response = client.get("/api/v1/summary")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_product(self, client, mock_ocp_summary):
+        """Test getting summary with product filter."""
+        # When
+        response = client.get("/api/v1/summary?products=ocp")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_versions(self, client, mock_ocp_summary):
+        """Test getting summary with version filter."""
+        # When
+        response = client.get("/api/v1/summary?versions=4.18.0")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_benchmarks(self, client, mock_ocp_summary):
+        """Test getting summary with benchmarks filter."""
+        # When
+        response = client.get("/api/v1/summary?benchmarks=cluster-density")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_configs(self, client, mock_ocp_summary):
+        """Test getting summary with configs filter."""
+        # When
+        response = client.get("/api/v1/summary?configs=config1")
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_date_filters(self, client, mock_ocp_summary):
+        """Test getting summary with date filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary?start_date=2024-01-01&end_date=2024-12-31"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_with_all_filters(self, client, mock_ocp_summary):
+        """Test getting summary with all filters."""
+        # When
+        response = client.get(
+            "/api/v1/summary?products=ocp&versions=4.18.0"
+            "&benchmarks=cluster-density&configs=config1"
+            "&start_date=2024-01-01&end_date=2024-12-31"
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_summary_endpoint_invalid_product(self, client, mock_ocp_summary):
+        """Test getting summary with invalid product."""
+        # When
+        response = client.get("/api/v1/summary?products=invalid_product")
+
+        # Then
+        assert response.status_code == 400
+
+
+class TestRouterConfiguration:
+    """Test the router configuration."""
+
+    def test_router_exists(self):
+        """Test that router is properly configured."""
+        # Then
+        assert router is not None
+        routes = [route.path for route in router.routes if hasattr(route, "path")]
+        assert len(routes) >= 4  # At least 4 endpoints
+
+    def test_router_has_products_endpoint(self):
+        """Test that router has products endpoint."""
+        # When
+        routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "path") and route.path == "/api/v1/summary/products"
+        ]
+
+        # Then
+        assert len(routes) == 1
+        assert "GET" in routes[0].methods
+
+    def test_router_has_versions_endpoint(self):
+        """Test that router has versions endpoint."""
+        # When
+        routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "path") and route.path == "/api/v1/summary/versions"
+        ]
+
+        # Then
+        assert len(routes) == 1
+        assert "GET" in routes[0].methods
+
+    def test_router_has_benchmarks_endpoint(self):
+        """Test that router has benchmarks endpoint."""
+        # When
+        routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "path") and route.path == "/api/v1/summary/benchmarks"
+        ]
+
+        # Then
+        assert len(routes) == 1
+        assert "GET" in routes[0].methods
+
+    def test_router_has_summary_endpoint(self):
+        """Test that router has summary endpoint."""
+        # When
+        routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "path") and route.path == "/api/v1/summary"
+        ]
+
+        # Then
+        assert len(routes) == 1
+        assert "GET" in routes[0].methods
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_versions_endpoint_with_empty_product_string(
+        self, client, mock_ocp_summary
+    ):
+        """Test versions endpoint with empty product string."""
+        # When
+        response = client.get("/api/v1/summary/versions?products=")
+
+        # Then
+        # Should handle empty string gracefully
+        assert response.status_code in [200, 400]
+
+    def test_benchmarks_endpoint_with_empty_filters(self, client, mock_ocp_summary):
+        """Test benchmarks endpoint with empty filter strings."""
+        # When
+        response = client.get(
+            "/api/v1/summary/benchmarks?versions=&benchmarks=&products="
+        )
+
+        # Then
+        # Should handle empty strings gracefully
+        assert response.status_code in [200, 400]
+
+    def test_summary_endpoint_with_special_characters(self, client, mock_ocp_summary):
+        """Test summary endpoint with special characters in filters."""
+        # When
+        response = client.get("/api/v1/summary?configs=test%20config")
+
+        # Then
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_collect_with_exception_in_method(self):
+        """Test collect handles exceptions in method calls gracefully."""
+        # Given
+        mock_summary = MockSummary("ocp")
+
+        # Create a method that raises an exception
+        async def failing_method():
+            raise ValueError("Test error")
+
+        mock_summary.get_versions = failing_method
+
+        context = {"ocp": ProductContext("ocp", mock_summary)}
+        products = "ocp"
+        method = "get_versions"
+
+        # When
+        result = await collect(products, context, method)
+
+        # Then - should handle error and return result (possibly empty)
+        assert isinstance(result, dict)
+
+    def test_products_endpoint_is_synchronous(self, client):
+        """Test that products endpoint is accessible and returns immediately."""
+        # When
+        response = client.get("/api/v1/summary/products")
+
+        # Then
+        assert response.status_code == 200
+        assert response.elapsed.total_seconds() < 1  # Should be fast

--- a/backend/tests/unit/test_summary_search.py
+++ b/backend/tests/unit/test_summary_search.py
@@ -1,0 +1,648 @@
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1.endpoints.summary.summary import BenchmarkBase
+from app.api.v1.endpoints.summary.summary_search import (
+    Benchmark,
+    PerfCiFingerprint,
+    SearchBenchmark,
+    SummarySearch,
+)
+
+"""Unit tests for the summary_search module classes.
+
+This file tests the classes and functionality defined in summary_search.py,
+including the Benchmark dataclass, PerfCiFingerprint extension, SummarySearch
+abstract class, and SearchBenchmark class. Uses concrete implementations to
+test abstract methods and achieve full coverage.
+
+Follows established patterns from other unit tests with Given-When-Then structure.
+
+Generated-by: Cursor
+"""
+
+
+# Concrete implementation of SummarySearch for testing
+class ConcreteSummarySearch(SummarySearch):
+    """Concrete implementation of SummarySearch for testing."""
+
+    def create_helper(self, benchmark: str) -> BenchmarkBase:
+        """Create a mock helper for testing."""
+        mock_helper = MagicMock(spec=BenchmarkBase)
+        mock_helper.benchmark = benchmark
+        return mock_helper
+
+    async def close(self):
+        """Override to call parent's close method."""
+        await super().close()
+
+    async def get_versions(self) -> dict[str, list[str]]:
+        """Implement abstract method."""
+        return {"4.18": ["4.18.0", "4.18.1"], "4.19": ["4.19.0"]}
+
+    async def get_benchmarks(self, version: str) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "cluster-density": ["config1", "config2"],
+            "node-density": ["config3"],
+        }
+
+    async def get_iterations(self, versions: Optional[str] = None) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {"iterations": [1, 2, 3], "versions": versions}
+
+    async def get_configs(
+        self, versions: Optional[str] = None, benchmarks: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {"configs": ["config1", "config2"], "versions": versions}
+
+    async def metric_aggregation(
+        self,
+        versions: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        configs: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "metrics": {"avg": 100, "max": 150, "min": 50},
+            "versions": versions,
+            "benchmarks": benchmarks,
+        }
+
+
+# Concrete implementation of SearchBenchmark for testing
+class ConcreteSearchBenchmark(SearchBenchmark):
+    """Concrete implementation of SearchBenchmark for testing."""
+
+    async def get_iteration_variants(
+        self, index: str, uuids: list[str]
+    ) -> dict[str, list[str]]:
+        """Implement abstract method."""
+        return {
+            "variants": ["variant1", "variant2"],
+            "index": index,
+            "uuid_count": len(uuids),
+        }
+
+    async def process(
+        self, version: str, config: str, iter: Any, uuids: list[str]
+    ) -> dict[str, Any]:
+        """Implement abstract method."""
+        return {
+            "version": version,
+            "config": config,
+            "iteration": iter,
+            "processed_uuids": len(uuids),
+        }
+
+    async def evaluate(self, metric: dict[str, Any]) -> str:
+        """Implement abstract method."""
+        if metric.get("value", 0) > 100:
+            return "high"
+        elif metric.get("value", 0) > 50:
+            return "medium"
+        return "low"
+
+
+class TestBenchmarkDataclass:
+    """Test cases for Benchmark dataclass functionality."""
+
+    def test_benchmark_with_index_only(self):
+        """Test Benchmark initialization with only index."""
+        # Given: A benchmark with only an index
+        index = "cdmv9dev-cluster-density"
+
+        # When: Creating a Benchmark instance
+        result = Benchmark(index=index)
+
+        # Then: Should create instance with index and None filter
+        assert result.index == index
+        assert result.filter is None
+
+    def test_benchmark_with_index_and_filter(self):
+        """Test Benchmark initialization with index and filter."""
+        # Given: A benchmark with index and filter
+        index = "cdmv9dev-quay"
+        filter_dict = {"benchmark": "quay-load-test"}
+
+        # When: Creating a Benchmark instance
+        result = Benchmark(index=index, filter=filter_dict)
+
+        # Then: Should create instance with both index and filter
+        assert result.index == index
+        assert result.filter == filter_dict
+        assert result.filter["benchmark"] == "quay-load-test"
+
+    def test_benchmark_filter_can_be_none(self):
+        """Test Benchmark filter defaults to None."""
+        # Given: A benchmark without filter specified
+        index = "cdmv9dev-test"
+
+        # When: Creating a Benchmark instance without filter
+        result = Benchmark(index=index)
+
+        # Then: Filter should be None
+        assert result.filter is None
+
+    def test_benchmark_with_complex_filter(self):
+        """Test Benchmark with complex filter dictionary."""
+        # Given: A benchmark with complex filter
+        index = "cdmv9dev-ocp"
+        filter_dict = {
+            "benchmark": "cluster-density-ms",
+            "platform": "aws",
+            "workerNodesCount": 120,
+        }
+
+        # When: Creating a Benchmark instance
+        result = Benchmark(index=index, filter=filter_dict)
+
+        # Then: Should preserve all filter values
+        assert result.index == index
+        assert result.filter["benchmark"] == "cluster-density-ms"
+        assert result.filter["platform"] == "aws"
+        assert result.filter["workerNodesCount"] == 120
+
+
+class TestPerfCiFingerprintDataclass:
+    """Test cases for PerfCiFingerprint dataclass functionality."""
+
+    def test_perfci_fingerprint_initialization(self):
+        """Test PerfCiFingerprint initialization with all fields."""
+        # Given: PerfCi fingerprint data
+        master_type = "m5.2xlarge"
+        master_count = 3
+        worker_type = "m5.4xlarge"
+        worker_count = 120
+
+        # When: Creating a PerfCiFingerprint instance
+        result = PerfCiFingerprint(
+            masterNodesType=master_type,
+            masterNodesCount=master_count,
+            workerNodesType=worker_type,
+            workerNodesCount=worker_count,
+        )
+
+        # Then: Should create instance with all fields
+        assert result.masterNodesType == master_type
+        assert result.masterNodesCount == master_count
+        assert result.workerNodesType == worker_type
+        assert result.workerNodesCount == worker_count
+
+    def test_perfci_fingerprint_key_method(self):
+        """Test PerfCiFingerprint key method includes abbreviated names."""
+        # Given: A PerfCiFingerprint instance
+        fingerprint = PerfCiFingerprint(
+            masterNodesType="m5.2xlarge",
+            masterNodesCount=3,
+            workerNodesType="m5.4xlarge",
+            workerNodesCount=120,
+        )
+
+        # When: Generating key
+        result = fingerprint.key()
+
+        # Then: Should use abbreviated metadata names
+        assert "mt=m5.2xlarge" in result  # masterNodesType abbreviated to 'mt'
+        assert "mc=3" in result  # masterNodesCount abbreviated to 'mc'
+        assert "wt=m5.4xlarge" in result  # workerNodesType abbreviated to 'wt'
+        assert "wc=120" in result  # workerNodesCount abbreviated to 'wc'
+
+    def test_perfci_fingerprint_json_method(self):
+        """Test PerfCiFingerprint json method returns dict."""
+        # Given: A PerfCiFingerprint instance
+        fingerprint = PerfCiFingerprint(
+            masterNodesType="m5.2xlarge",
+            masterNodesCount=3,
+            workerNodesType="m5.4xlarge",
+            workerNodesCount=120,
+        )
+
+        # When: Converting to json
+        result = fingerprint.json()
+
+        # Then: Should return dictionary with all fields
+        assert isinstance(result, dict)
+        assert result["masterNodesType"] == "m5.2xlarge"
+        assert result["masterNodesCount"] == 3
+        assert result["workerNodesType"] == "m5.4xlarge"
+        assert result["workerNodesCount"] == 120
+
+    def test_perfci_fingerprint_parse_from_dict(self):
+        """Test PerfCiFingerprint parse method creates instance from dict."""
+        # Given: A dictionary with fingerprint data
+        data = {
+            "masterNodesType": "m5.xlarge",
+            "masterNodesCount": 3,
+            "workerNodesType": "m5.2xlarge",
+            "workerNodesCount": 60,
+        }
+
+        # When: Parsing from dict
+        result = PerfCiFingerprint.parse(data)
+
+        # Then: Should create instance with correct values
+        assert isinstance(result, PerfCiFingerprint)
+        assert result.masterNodesType == "m5.xlarge"
+        assert result.masterNodesCount == 3
+        assert result.workerNodesType == "m5.2xlarge"
+        assert result.workerNodesCount == 60
+
+    def test_perfci_fingerprint_filter_includes_keyword_for_key_fields(self):
+        """Test PerfCiFingerprint filter method adds .keyword for key fields."""
+        # Given: PerfCiFingerprint class
+        # When: Getting filter structure
+        result = PerfCiFingerprint.filter()
+
+        # Then: Should add .keyword suffix for key=True metadata fields
+        filter_fields = [f["term"]["field"] for f in result]
+        assert "masterNodesType.keyword" in filter_fields  # key=True
+        assert "workerNodesType.keyword" in filter_fields  # key=True
+        assert "masterNodesCount" in filter_fields  # no key metadata means no .keyword
+        assert "workerNodesCount" in filter_fields  # no key metadata means no .keyword
+
+    def test_perfci_fingerprint_composite_aggregation(self):
+        """Test PerfCiFingerprint composite method generates terms aggregation."""
+        # Given: PerfCiFingerprint class
+        # When: Getting composite structure
+        result = PerfCiFingerprint.composite()
+
+        # Then: Should return list of terms aggregations for each field
+        assert isinstance(result, list)
+        assert len(result) == 4  # Four fields in PerfCiFingerprint
+
+        # Verify structure of composite aggregations
+        field_names = []
+        for item in result:
+            assert isinstance(item, dict)
+            field_name = list(item.keys())[0]
+            field_names.append(field_name)
+            assert "terms" in item[field_name]
+            assert "field" in item[field_name]["terms"]
+
+        # Verify all expected fields are present
+        assert "masterNodesType" in field_names
+        assert "masterNodesCount" in field_names
+        assert "workerNodesType" in field_names
+        assert "workerNodesCount" in field_names
+
+
+class TestSummarySearch:
+    """Test cases for SummarySearch class functionality."""
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_summary_search_initialization(self, mock_elastic_service):
+        """Test SummarySearch initialization with benchmarks."""
+        # Given: Product and benchmarks configuration
+        product = "ocp"
+        configpath = "ocp.elasticsearch"
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+            "node-density": Benchmark(index="cdmv9dev-node-density"),
+        }
+
+        # When: Creating SummarySearch instance
+        result = ConcreteSummarySearch(
+            product=product, configpath=configpath, benchmarks=benchmarks
+        )
+
+        # Then: Should initialize with correct values
+        assert result.product == product
+        assert result.configpath == configpath
+        assert result.benchmarks == benchmarks
+        assert result.date_filter is None
+        assert result.benchmark_helper == {}
+        mock_elastic_service.assert_called_once_with(configpath)
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_summary_search_default_benchmarks(self, mock_elastic_service):
+        """Test SummarySearch initialization with default empty benchmarks."""
+        # Given: Product without benchmarks
+        product = "ocp"
+
+        # When: Creating SummarySearch instance without benchmarks
+        result = ConcreteSummarySearch(product=product)
+
+        # Then: Should initialize with empty benchmarks dict
+        assert result.benchmarks == {}
+        assert result.benchmark_helper == {}
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_index_returns_benchmark_index(self, mock_elastic_service):
+        """Test get_index returns correct index for benchmark."""
+        # Given: SummarySearch with benchmarks
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+            "node-density": Benchmark(index="cdmv9dev-node-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting index for benchmark
+        result = summary.get_index("cluster-density")
+
+        # Then: Should return correct index
+        assert result == "cdmv9dev-cluster-density"
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_index_returns_none_for_unknown_benchmark(self, mock_elastic_service):
+        """Test get_index returns None for unknown benchmark."""
+        # Given: SummarySearch with benchmarks
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting index for unknown benchmark
+        result = summary.get_index("unknown-benchmark")
+
+        # Then: Should return None
+        assert result is None
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_filter_returns_benchmark_filter(self, mock_elastic_service):
+        """Test get_filter returns correct filter for benchmark."""
+        # Given: SummarySearch with filtered benchmarks
+        benchmarks = {
+            "quay-load": Benchmark(
+                index="cdmv9dev-quay", filter={"benchmark": "quay-load-test"}
+            ),
+        }
+        summary = ConcreteSummarySearch(product="quay", benchmarks=benchmarks)
+
+        # When: Getting filter for benchmark
+        result = summary.get_filter("quay-load")
+
+        # Then: Should return correct filter
+        assert result == {"benchmark": "quay-load-test"}
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_filter_returns_none_when_no_filter(self, mock_elastic_service):
+        """Test get_filter returns None when benchmark has no filter."""
+        # Given: SummarySearch with unfiltered benchmark
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting filter for benchmark without filter
+        result = summary.get_filter("cluster-density")
+
+        # Then: Should return None
+        assert result is None
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_filter_returns_none_for_unknown_benchmark(self, mock_elastic_service):
+        """Test get_filter returns None for unknown benchmark."""
+        # Given: SummarySearch with benchmarks
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting filter for unknown benchmark
+        result = summary.get_filter("unknown-benchmark")
+
+        # Then: Should return None
+        assert result is None
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_helper_creates_and_caches_helper(self, mock_elastic_service):
+        """Test get_helper creates helper and caches it."""
+        # Given: SummarySearch instance
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting helper first time
+        result1 = summary.get_helper("cluster-density")
+
+        # Then: Should create and cache helper
+        assert result1 is not None
+        assert "cluster-density" in summary.benchmark_helper
+        assert summary.benchmark_helper["cluster-density"] == result1
+
+        # When: Getting helper second time
+        result2 = summary.get_helper("cluster-density")
+
+        # Then: Should return cached helper (same instance)
+        assert result2 is result1
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_get_helper_different_benchmarks(self, mock_elastic_service):
+        """Test get_helper creates separate helpers for different benchmarks."""
+        # Given: SummarySearch with multiple benchmarks
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+            "node-density": Benchmark(index="cdmv9dev-node-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Getting helpers for different benchmarks
+        helper1 = summary.get_helper("cluster-density")
+        helper2 = summary.get_helper("node-density")
+
+        # Then: Should create different helpers
+        assert helper1 is not helper2
+        assert helper1.benchmark == "cluster-density"
+        assert helper2.benchmark == "node-density"
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_set_date_filter_with_start_and_end(self, mock_elastic_service):
+        """Test set_date_filter creates filter with start and end dates."""
+        # Given: SummarySearch instance
+        summary = ConcreteSummarySearch(product="ocp")
+        start_date = "2024-01-01"
+        end_date = "2024-01-31"
+
+        # When: Setting date filter
+        summary.set_date_filter(start_date, end_date)
+
+        # Then: Should create date filter with range
+        assert summary.date_filter is not None
+        assert "range" in summary.date_filter
+        assert "timestamp" in summary.date_filter["range"]
+        assert summary.date_filter["range"]["timestamp"]["gte"] == start_date
+        assert summary.date_filter["range"]["timestamp"]["lte"] == end_date
+        assert summary.date_filter["range"]["timestamp"]["format"] == "yyyy-MM-dd"
+        assert summary.end_date == end_date
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_set_date_filter_with_start_only(self, mock_elastic_service):
+        """Test set_date_filter creates filter with only start date."""
+        # Given: SummarySearch instance
+        summary = ConcreteSummarySearch(product="ocp")
+        start_date = "2024-01-01"
+
+        # When: Setting date filter with only start
+        summary.set_date_filter(start_date, None)
+
+        # Then: Should create date filter with only gte
+        assert summary.date_filter is not None
+        assert "range" in summary.date_filter
+        assert summary.date_filter["range"]["timestamp"]["gte"] == start_date
+        assert "lte" not in summary.date_filter["range"]["timestamp"]
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_set_date_filter_with_end_only(self, mock_elastic_service):
+        """Test set_date_filter creates filter with only end date."""
+        # Given: SummarySearch instance
+        summary = ConcreteSummarySearch(product="ocp")
+        end_date = "2024-01-31"
+
+        # When: Setting date filter with only end
+        summary.set_date_filter(None, end_date)
+
+        # Then: Should create date filter with only lte
+        assert summary.date_filter is not None
+        assert "range" in summary.date_filter
+        assert summary.date_filter["range"]["timestamp"]["lte"] == end_date
+        assert "gte" not in summary.date_filter["range"]["timestamp"]
+        assert summary.end_date == end_date
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_set_date_filter_with_no_dates(self, mock_elastic_service):
+        """Test set_date_filter clears filter when no dates provided."""
+        # Given: SummarySearch instance with existing filter
+        summary = ConcreteSummarySearch(product="ocp")
+        summary.date_filter = {"existing": "filter"}
+
+        # When: Setting date filter with no dates
+        summary.set_date_filter(None, None)
+
+        # Then: Should clear date filter
+        assert summary.date_filter is None
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    async def test_close_calls_service_close(self, mock_elastic_service):
+        """Test close method calls ElasticService.close."""
+        # Given: SummarySearch instance with mock service
+        mock_service_instance = AsyncMock()
+        mock_elastic_service.return_value = mock_service_instance
+        summary = ConcreteSummarySearch(product="ocp")
+
+        # When: Closing summary
+        await summary.close()
+
+        # Then: Should call service.close()
+        mock_service_instance.close.assert_called_once()
+
+
+class TestSearchBenchmark:
+    """Test cases for SearchBenchmark class functionality."""
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_search_benchmark_initialization(self, mock_elastic_service):
+        """Test SearchBenchmark initialization."""
+        # Given: Summary with benchmark
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+
+        # When: Creating SearchBenchmark instance
+        result = ConcreteSearchBenchmark(summary=summary, benchmark="cluster-density")
+
+        # Then: Should initialize with correct values
+        assert result.summary == summary
+        assert result.benchmark == "cluster-density"
+        assert result.index == "cdmv9dev-cluster-density"
+
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    def test_search_benchmark_index_none_for_unknown(self, mock_elastic_service):
+        """Test SearchBenchmark index is None for unknown benchmark."""
+        # Given: Summary without specific benchmark
+        summary = ConcreteSummarySearch(product="ocp", benchmarks={})
+
+        # When: Creating SearchBenchmark for unknown benchmark
+        result = ConcreteSearchBenchmark(summary=summary, benchmark="unknown-benchmark")
+
+        # Then: Should have None index
+        assert result.summary == summary
+        assert result.benchmark == "unknown-benchmark"
+        assert result.index is None
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    async def test_search_benchmark_get_iteration_variants(self, mock_elastic_service):
+        """Test SearchBenchmark get_iteration_variants abstract method implementation."""
+        # Given: SearchBenchmark instance
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+        benchmark = ConcreteSearchBenchmark(
+            summary=summary, benchmark="cluster-density"
+        )
+
+        # When: Calling get_iteration_variants
+        result = await benchmark.get_iteration_variants(
+            index="test-index", uuids=["uuid1", "uuid2", "uuid3"]
+        )
+
+        # Then: Should return expected structure
+        assert result["index"] == "test-index"
+        assert result["uuid_count"] == 3
+        assert "variants" in result
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    async def test_search_benchmark_process(self, mock_elastic_service):
+        """Test SearchBenchmark process abstract method implementation."""
+        # Given: SearchBenchmark instance
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+        benchmark = ConcreteSearchBenchmark(
+            summary=summary, benchmark="cluster-density"
+        )
+
+        # When: Calling process
+        result = await benchmark.process(
+            version="4.18.0",
+            config="aws-120",
+            iter=5,
+            uuids=["uuid1", "uuid2"],
+        )
+
+        # Then: Should return processed data
+        assert result["version"] == "4.18.0"
+        assert result["config"] == "aws-120"
+        assert result["iteration"] == 5
+        assert result["processed_uuids"] == 2
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.endpoints.summary.summary_search.ElasticService")
+    async def test_search_benchmark_evaluate(self, mock_elastic_service):
+        """Test SearchBenchmark evaluate abstract method implementation."""
+        # Given: SearchBenchmark instance
+        benchmarks = {
+            "cluster-density": Benchmark(index="cdmv9dev-cluster-density"),
+        }
+        summary = ConcreteSummarySearch(product="ocp", benchmarks=benchmarks)
+        benchmark = ConcreteSearchBenchmark(
+            summary=summary, benchmark="cluster-density"
+        )
+
+        # When: Calling evaluate with high value
+        result_high = await benchmark.evaluate({"value": 150})
+
+        # Then: Should return 'high'
+        assert result_high == "high"
+
+        # When: Calling evaluate with medium value
+        result_medium = await benchmark.evaluate({"value": 75})
+
+        # Then: Should return 'medium'
+        assert result_medium == "medium"
+
+        # When: Calling evaluate with low value
+        result_low = await benchmark.evaluate({"value": 25})
+
+        # Then: Should return 'low'
+        assert result_low == "low"

--- a/run-local.sh
+++ b/run-local.sh
@@ -27,8 +27,8 @@ if [ ! -f "${CPT_CONFIG}" ]; then
 fi
 
 # Make sure all dependencies are installed.
-echo "Installing dependencies..."
 temp_file=$(mktemp)
+echo "Installing dependencies... (${temp_file})"
 (
     cd "${BACKEND}"
     poetry install


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is an attempt to provide a high-level "release health" view tracking the designated KPI metric for each benchmark, evaluating the KPI metric across comparable runs and evaluating the "readiness" of each sequence.

Right now, only OCP is supported, and only the benchmarks which have "graph" support in the current code base, presuming that the graphed metric represents the "KPI" for each benchmark. The evaluation algorithm is simplistic, and just a placeholder for future development.

## Related Tickets & Documents

[PANDA-964](https://issues.redhat.com/browse/PANDA-964) Summary page

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Worked with my pair programming buddy Cursor to generate unit tests that provide near 100% code coverage for each new module. These are completely new APIs which should have no impact on existing code.