### PR TITLE
Add RHOSO results dashboard links

### DIFF
--- a/frontend/src/assets/constants/osoDashboardConstants.js
+++ b/frontend/src/assets/constants/osoDashboardConstants.js
@@ -1,0 +1,16 @@
+/**
+ * OSO (RHOSO) dashboard and artifact link templates.
+ * Placeholders are replaced in OsoDashboardLink using row data.
+ */
+
+/** RHOSO Performance Dashboard (Grafana). Use row startDate/endDate as ms for {from}/{to}, buildId for {buildId}. */
+export const RHOSO_PERFORMANCE_DASHBOARD_TEMPLATE =
+  "https://grafana.app.intlab.redhat.com/d/7584fd37-1f5e-4ad6-a1ca-fb56586a660c/rhoso-performance-dashboard?orgId=2&from={from}&to={to}&var-Datasource=osp-metrics-from-ocp&var-Index=All&var-job_name=cpt-{buildId}&var-node=All";
+
+/** Rally Compare Dashboard (Grafana). Use row uuid for {uuid}. */
+export const RALLY_COMPARE_DASHBOARD_TEMPLATE =
+  "https://grafana.app.intlab.redhat.com/d/V8QvcQmvz/rally-compare-dashboard?orgId=2&refresh=5s&from=now-90d&to=now&var-Datasource=browbeat-rally-*&var-uuid={uuid}&var-scenario=All&var-action=All";
+
+/** Pub / artifacts. Use row buildId for {buildId} */
+export const PUB_ARTIFACTS_TEMPLATE =
+  "https://perf1.perf.eng.bos2.dc.redhat.com/pub/RHOSO_CPT/{buildId}/";

--- a/frontend/src/components/atoms/LinkIcon/index.jsx
+++ b/frontend/src/components/atoms/LinkIcon/index.jsx
@@ -4,8 +4,16 @@ const LinkIcon = (props) => {
 
   return (
     <>
-      <a target={target} href={link}>
-        <img src={src} alt={altText} style={{ height: height, width: width }} />
+      <a target={target} href={link} rel="noopener noreferrer">
+        {src ? (
+          <img
+            src={src}
+            alt={altText}
+            style={{ height: height, width: width }}
+          />
+        ) : (
+          altText
+        )}
       </a>
     </>
   );

--- a/frontend/src/components/atoms/osoDashboardLink/index.jsx
+++ b/frontend/src/components/atoms/osoDashboardLink/index.jsx
@@ -1,0 +1,64 @@
+import * as CONSTANTS from "@/assets/constants/osoDashboardConstants";
+import LinkIcon from "@/components/atoms/LinkIcon";
+import Proptypes from "prop-types";
+import { useMemo } from "react";
+
+const OsoDashboardLink = (props) => {
+  const { config, startDate, endDate } = props;
+
+  const links = useMemo(() => {
+    const from = startDate != null ? Number(startDate) : null;
+    const to = endDate != null ? Number(endDate) : null;
+    const uuid = config?.uuid?.trim?.() || "";
+    const buildId = config?.buildId?.trim?.() || "";
+
+    const link1 =
+      from != null && to != null && buildId
+        ? CONSTANTS.RHOSO_PERFORMANCE_DASHBOARD_TEMPLATE.replace(
+            "{from}",
+            String(from)
+          )
+          .replace("{to}", String(to))
+          .replace("{buildId}", buildId)
+        : null;
+
+    const link2 = uuid
+      ? CONSTANTS.RALLY_COMPARE_DASHBOARD_TEMPLATE.replace("{uuid}", uuid)
+      : null;
+
+    const link3 = buildId
+      ? CONSTANTS.PUB_ARTIFACTS_TEMPLATE.replace("{buildId}", buildId)
+      : null;
+
+    return [
+      { url: link1, altText: "Performance Dashboard" },
+      { url: link2, altText: "Rally Dashboard" },
+      { url: link3, altText: "Artifacts" },
+    ];
+  }, [config?.uuid, config?.buildId, startDate, endDate]);
+
+  return (
+    <>
+      {links.map(
+        (item, idx) =>
+          item.url && (
+            <span key={idx} style={{ marginRight: "0.5rem" }}>
+              <LinkIcon
+                link={item.url}
+                target="_blank"
+                altText={item.altText}
+              />
+            </span>
+          )
+      )}
+    </>
+  );
+};
+
+OsoDashboardLink.propTypes = {
+  config: Proptypes.object,
+  startDate: Proptypes.number,
+  endDate: Proptypes.number,
+};
+
+export default OsoDashboardLink;

--- a/frontend/src/components/molecules/TasksInfo/index.jsx
+++ b/frontend/src/components/molecules/TasksInfo/index.jsx
@@ -9,6 +9,7 @@ import {
 import GrafanaLink from "@/components/atoms/GrafanaLink";
 import JenkinsIcon from "@/assets/images/jenkins-icon.svg";
 import LinkIcon from "@/components/atoms/LinkIcon";
+import OsoDashboardLink from "@/components/atoms/osoDashboardLink";
 import Proptypes from "prop-types";
 import ProwIcon from "@/assets/images/prow-icon.png";
 import SplunkLink from "@/components/atoms/SplunkLink";
@@ -61,6 +62,13 @@ const TasksInfo = (props) => {
         )}
         {props.type === "telco" && (
           <SplunkLink config={config} startDate={startDate} endDate={endDate} />
+        )}
+        {props.type === "oso" && (
+          <OsoDashboardLink
+            config={config}
+            startDate={startDate - 10 * 60 * 1000}
+            endDate={endDate - 5 * 60 * 1000}
+          />
         )}
         <LinkIcon
           link={config.buildUrl}


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the Tasks run field, add the RHOSO rally results, performance results, rally graph, and logs backup link, so any user can easily move to the results dashboard and see the results

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
